### PR TITLE
WIP: Add 7in5bc support, #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ epd.update_and_display_frame(&mut spi, &display.buffer())?;
 | Device (with Link) | Colors | Flexible Display | Partial Refresh | Supported | Tested |
 | :---: | --- | :---: | :---: | :---: | :---: |
 | [7.5 Inch B/W V2 (A)](https://www.waveshare.com/product/7.5inch-e-paper-hat.htm) [[1](#1-75-inch-bw-v2-a)] | Black, White | ✕ | ✕ | ✔ | ✔ |
+| [7.5 Inch B/W/R (B/C)](https://www.waveshare.com/7.5inch-e-Paper-HAT-B.htm) | Black, White, Red | ✔ | ✕ | ✔ | ✔ |
 | [7.5 Inch B/W (A)](https://www.waveshare.com/product/7.5inch-e-paper-hat.htm) | Black, White | ✕ | ✕ | ✔ | ✔ |
 | [4.2 Inch B/W (A)](https://www.waveshare.com/product/4.2inch-e-paper-module.htm) | Black, White | ✕ | Not officially [[2](#2-42-inch-e-ink-blackwhite---partial-refresh)] | ✔ | ✔ |
 | [1.54 Inch B/W (A)](https://www.waveshare.com/1.54inch-e-Paper-Module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |

--- a/src/epd7in5bc/command.rs
+++ b/src/epd7in5bc/command.rs
@@ -1,0 +1,154 @@
+//! SPI Commands for the Waveshare 7.5" E-Ink Display
+
+use crate::traits;
+
+/// EPD7in5b commands
+///
+/// Should rarely (never?) be needed directly.
+///
+/// For more infos about the addresses and what they are doing look into the PDFs.
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone)]
+pub(crate) enum Command {
+    /// Set Resolution, LUT selection, BWR pixels, gate scan direction, source shift
+    /// direction, booster switch, soft reset.
+    PANEL_SETTING = 0x00,
+
+    /// Selecting internal and external power
+    POWER_SETTING = 0x01,
+
+    /// After the Power Off command, the driver will power off following the Power Off
+    /// Sequence; BUSY signal will become "0". This command will turn off charge pump,
+    /// T-con, source driver, gate driver, VCOM, and temperature sensor, but register
+    /// data will be kept until VDD becomes OFF. Source Driver output and Vcom will remain
+    /// as previous condition, which may have 2 conditions: 0V or floating.
+    POWER_OFF = 0x02,
+
+    /// Setting Power OFF sequence
+    POWER_OFF_SEQUENCE_SETTING = 0x03,
+
+    /// Turning On the Power
+    ///
+    /// After the Power ON command, the driver will power on following the Power ON
+    /// sequence. Once complete, the BUSY signal will become "1".
+    POWER_ON = 0x04,
+
+    /// Starting data transmission
+    BOOSTER_SOFT_START = 0x06,
+
+    /// This command makes the chip enter the deep-sleep mode to save power.
+    ///
+    /// The deep sleep mode would return to stand-by by hardware reset.
+    ///
+    /// The only one parameter is a check code, the command would be excuted if check code = 0xA5.
+    DEEP_SLEEP = 0x07,
+
+    /// This command starts transmitting data and write them into SRAM. To complete data
+    /// transmission, command DSP (Data Stop) must be issued. Then the chip will start to
+    /// send data/VCOM for panel.
+    DATA_START_TRANSMISSION_1 = 0x10,
+
+    /// To stop data transmission, this command must be issued to check the `data_flag`.
+    ///
+    /// After this command, BUSY signal will become "0" until the display update is
+    /// finished.
+    DATA_STOP = 0x11,
+
+    /// After this command is issued, driver will refresh display (data/VCOM) according to
+    /// SRAM data and LUT.
+    ///
+    /// After Display Refresh command, BUSY signal will become "0" until the display
+    /// update is finished.
+    DISPLAY_REFRESH = 0x12,
+
+    /// After this command is issued, image process engine will find thin lines/pixels
+    /// from frame SRAM and update the frame SRAM for applying new gray level waveform.
+    ///
+    /// After "Image Process Command", BUSY_N signal will become "0" until image process
+    /// is finished.
+    IMAGE_PROCESS = 0x13,
+
+    /// This command builds the VCOM Look-Up Table (LUTC).
+    LUT_FOR_VCOM = 0x20,
+    /// This command builds the Black Look-Up Table (LUTB).
+    LUT_BLACK = 0x21,
+    /// This command builds the White Look-Up Table (LUTW).
+    LUT_WHITE = 0x22,
+    /// This command builds the Gray1 Look-Up Table (LUTG1).
+    LUT_GRAY_1 = 0x23,
+    /// This command builds the Gray2 Look-Up Table (LUTG2).
+    LUT_GRAY_2 = 0x24,
+    /// This command builds the Red0 Look-Up Table (LUTR0).
+    LUT_RED_0 = 0x25,
+    /// This command builds the Red1 Look-Up Table (LUTR1).
+    LUT_RED_1 = 0x26,
+    /// This command builds the Red2 Look-Up Table (LUTR2).
+    LUT_RED_2 = 0x27,
+    /// This command builds the Red3 Look-Up Table (LUTR3).
+    LUT_RED_3 = 0x28,
+    /// This command builds the XON Look-Up Table (LUTXON).
+    LUT_XON = 0x29,
+
+    /// The command controls the PLL clock frequency.
+    PLL_CONTROL = 0x30,
+
+    /// This command reads the temperature sensed by the temperature sensor.
+    TEMPERATURE_SENSOR_COMMAND = 0x40,
+    /// This command selects the Internal or External temperature sensor.
+    TEMPERATURE_CALIBRATION = 0x41,
+    /// This command could write data to the external temperature sensor.
+    TEMPERATURE_SENSOR_WRITE = 0x42,
+    /// This command could read data from the external temperature sensor.
+    TEMPERATURE_SENSOR_READ = 0x43,
+
+    /// This command indicates the interval of Vcom and data output. When setting the
+    /// vertical back porch, the total blanking will be kept (20 Hsync).
+    VCOM_AND_DATA_INTERVAL_SETTING = 0x50,
+    /// This command indicates the input power condition. Host can read this flag to learn
+    /// the battery condition.
+    LOW_POWER_DETECTION = 0x51,
+
+    /// This command defines non-overlap period of Gate and Source.
+    TCON_SETTING = 0x60,
+    /// This command defines alternative resolution and this setting is of higher priority
+    /// than the RES\[1:0\] in R00H (PSR).
+    TCON_RESOLUTION = 0x61,
+    /// This command defines MCU host direct access external memory mode.
+    SPI_FLASH_CONTROL = 0x65,
+
+    /// The LUT_REV / Chip Revision is read from OTP address = 25001 and 25000.
+    REVISION = 0x70,
+    /// This command reads the IC status.
+    GET_STATUS = 0x71,
+
+    /// This command implements related VCOM sensing setting.
+    AUTO_MEASUREMENT_VCOM = 0x80,
+    /// This command gets the VCOM value.
+    READ_VCOM_VALUE = 0x81,
+    /// This command sets `VCOM_DC` value.
+    VCM_DC_SETTING = 0x82,
+
+    /// This is in all the Waveshare controllers for EPD7in5, but it's not documented
+    /// anywhere in the datasheet `¯\_(ツ)_/¯`
+    FLASH_MODE = 0xE5,
+}
+
+impl traits::Command for Command {
+    /// Returns the address of the command
+    fn address(self) -> u8 {
+        self as u8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::Command as CommandTrait;
+
+    #[test]
+    fn command_addr() {
+        assert_eq!(Command::PANEL_SETTING.address(), 0x00);
+        assert_eq!(Command::DISPLAY_REFRESH.address(), 0x12);
+    }
+}

--- a/src/epd7in5bc/graphics.rs
+++ b/src/epd7in5bc/graphics.rs
@@ -1,0 +1,146 @@
+use crate::epd7in5::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
+use crate::graphics::{Display, DisplayRotation};
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::*;
+
+/// Full size buffer for use with the 7in5 EPD
+///
+/// Can also be manually constructed:
+/// `buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); WIDTH / 8 * HEIGHT]`
+pub struct Display7in5bc {
+    buffer: [u8; WIDTH as usize * HEIGHT as usize / 8],
+    rotation: DisplayRotation,
+}
+
+impl Default for Display7in5bc {
+    fn default() -> Self {
+        Display7in5bc {
+            buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value();
+                WIDTH as usize * HEIGHT as usize / 8],
+            rotation: DisplayRotation::default(),
+        }
+    }
+}
+
+impl DrawTarget<BinaryColor> for Display7in5bc {
+    type Error = core::convert::Infallible;
+
+    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
+        self.draw_helper(WIDTH, HEIGHT, pixel)
+    }
+
+    fn size(&self) -> Size {
+        Size::new(WIDTH, HEIGHT)
+    }
+}
+
+impl Display for Display7in5bc {
+    fn buffer(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    fn get_mut_buffer(&mut self) -> &mut [u8] {
+        &mut self.buffer
+    }
+
+    fn set_rotation(&mut self, rotation: DisplayRotation) {
+        self.rotation = rotation;
+    }
+
+    fn rotation(&self) -> DisplayRotation {
+        self.rotation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::Black;
+    use crate::color::Color;
+    use crate::epd7in5;
+    use crate::graphics::{Display, DisplayRotation};
+    use embedded_graphics::{primitives::Line, style::PrimitiveStyle};
+
+    // test buffer length
+    #[test]
+    fn graphics_size() {
+        let display = Display7in5bc::default();
+        assert_eq!(display.buffer().len(), 30720);
+    }
+
+    // test default background color on all bytes
+    #[test]
+    fn graphics_default() {
+        let display = Display7in5bc::default();
+        for &byte in display.buffer() {
+            assert_eq!(byte, epd7in5::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+
+    #[test]
+    fn graphics_rotation_0() {
+        let mut display = Display7in5bc::default();
+        let _ = Line::new(Point::new(0, 0), Point::new(7, 0))
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .draw(&mut display);
+
+        let buffer = display.buffer();
+
+        assert_eq!(buffer[0], Color::Black.get_byte_value());
+
+        for &byte in buffer.iter().skip(1) {
+            assert_eq!(byte, epd7in5::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+
+    #[test]
+    fn graphics_rotation_90() {
+        let mut display = Display7in5bc::default();
+        display.set_rotation(DisplayRotation::Rotate90);
+        let _ = Line::new(Point::new(0, 632), Point::new(0, 639))
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .draw(&mut display);
+
+        let buffer = display.buffer();
+
+        assert_eq!(buffer[0], Color::Black.get_byte_value());
+
+        for &byte in buffer.iter().skip(1) {
+            assert_eq!(byte, epd7in5::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+
+    #[test]
+    fn graphics_rotation_180() {
+        let mut display = Display7in5bc::default();
+        display.set_rotation(DisplayRotation::Rotate180);
+        let _ = Line::new(Point::new(632, 383), Point::new(639, 383))
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .draw(&mut display);
+
+        let buffer = display.buffer();
+
+        assert_eq!(buffer[0], Color::Black.get_byte_value());
+
+        for &byte in buffer.iter().skip(1) {
+            assert_eq!(byte, epd7in5::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+
+    #[test]
+    fn graphics_rotation_270() {
+        let mut display = Display7in5bc::default();
+        display.set_rotation(DisplayRotation::Rotate270);
+        let _ = Line::new(Point::new(383, 0), Point::new(383, 7))
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .draw(&mut display);
+
+        let buffer = display.buffer();
+
+        assert_eq!(buffer[0], Color::Black.get_byte_value());
+
+        for &byte in buffer.iter().skip(1) {
+            assert_eq!(byte, epd7in5::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+}

--- a/src/epd7in5bc/mod.rs
+++ b/src/epd7in5bc/mod.rs
@@ -111,7 +111,7 @@ where
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         // Reset the device
-        self.interface.reset(delay);
+        self.interface.reset(delay, 10);
 
         // Set the power settings
         self.cmd_with_data(spi, Command::POWER_SETTING, &[0x37, 0x00])?;

--- a/src/epd7in5bc/mod.rs
+++ b/src/epd7in5bc/mod.rs
@@ -1,0 +1,430 @@
+//! A simple Driver for the Waveshare 7.5" (B/C) E-Ink Display via SPI
+//!
+//! # References
+//!
+//! - [Datasheet](http://www.waveshare.com/wiki/7.5inch_e-Paper_HAT_(B))
+//! - [Waveshare C driver](https://github.com/waveshare/e-Paper/blob/702def06bcb75983c98b0f9d25d43c552c248eb0/RaspberryPi%26JetsonNano/c/lib/e-Paper/EPD_7in5bc.c
+//! - [Waveshare Python driver](https://github.com/waveshare/e-Paper/blob/702def06bcb75983c98b0f9d25d43c552c248eb0/RaspberryPi%26JetsonNano/python/lib/waveshare_epd/epd7in5bc.py)
+//!
+//! //! # Example for the Waveshare 7.5" (B/C) E-Ink Display
+//!
+//!```rust, no_run
+//!# use embedded_hal_mock::*;
+//!# fn main() -> Result<(), MockError> {
+//!use embedded_graphics::{
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+//!};
+//!use epd_waveshare::{epd7in5bc::*, prelude::*};
+//!#
+//!# let expectations = [];
+//!# let mut spi = spi::Mock::new(&expectations);
+//!# let expectations = [];
+//!# let cs_pin = pin::Mock::new(&expectations);
+//!# let busy_in = pin::Mock::new(&expectations);
+//!# let dc = pin::Mock::new(&expectations);
+//!# let rst = pin::Mock::new(&expectations);
+//!# let mut delay = delay::MockNoop::new();
+//!
+//!// Setup EPD
+//!let mut epd = EPD7in5bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+//!
+//!// Use display graphics from embedded-graphics
+//!// This display is for the black/white pixels
+//!let mut mono_display = Display7in5bc::default();
+//!
+//!// Use embedded graphics for drawing
+//!// A black line
+//!let _ = Line::new(Point::new(0, 120), Point::new(0, 200))
+//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+//!    .draw(&mut mono_display);
+//!
+//!// Use a second display for red/yellow
+//!let mut chromatic_display = Display7in5bc::default();
+//!
+//!// We use `Black` but it will be shown as red/yellow
+//!let _ = Line::new(Point::new(15, 120), Point::new(15, 200))
+//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+//!    .draw(&mut chromatic_display);
+//!
+//!// Display updated frame
+//!epd.update_color_frame(
+//!    &mut spi,
+//!    &mono_display.buffer(),
+//!    &chromatic_display.buffer()
+//!)?;
+//!epd.display_frame(&mut spi)?;
+//!
+//!// Set the EPD to sleep
+//!epd.sleep(&mut spi)?;
+//!# Ok(())
+//!# }
+//!```
+
+use embedded_hal::{
+    blocking::{delay::*, spi::Write},
+    digital::v2::{InputPin, OutputPin},
+};
+
+use crate::color::Color;
+use crate::interface::DisplayInterface;
+use crate::traits::{
+    InternalWiAdditions, RefreshLUT, WaveshareDisplay, WaveshareThreeColorDisplay,
+};
+
+pub(crate) mod command;
+use self::command::Command;
+
+#[cfg(feature = "graphics")]
+mod graphics;
+#[cfg(feature = "graphics")]
+pub use self::graphics::Display7in5bc;
+
+/// Width of the display
+pub const WIDTH: u32 = 640;
+/// Height of the display
+pub const HEIGHT: u32 = 384;
+/// Default Background Color
+pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
+const IS_BUSY_LOW: bool = true;
+
+/// EPD7in5bc driver
+///
+pub struct EPD7in5bc<SPI, CS, BUSY, DC, RST> {
+    /// Connection Interface
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST>,
+    /// Background Color
+    color: Color,
+}
+
+impl<SPI, CS, BUSY, DC, RST> InternalWiAdditions<SPI, CS, BUSY, DC, RST>
+    for EPD7in5bc<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn init<DELAY: DelayMs<u8>>(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        // Reset the device
+        self.interface.reset(delay);
+
+        // Set the power settings
+        self.cmd_with_data(spi, Command::POWER_SETTING, &[0x37, 0x00])?;
+
+        // Set the panel settings:
+        // - 600 x 448
+        // - Using LUT from external flash
+        self.cmd_with_data(spi, Command::PANEL_SETTING, &[0xCF, 0x08])?;
+
+        // Start the booster
+        self.cmd_with_data(spi, Command::BOOSTER_SOFT_START, &[0xC7, 0xCC, 0x28])?;
+
+        // Power on
+        self.command(spi, Command::POWER_ON)?;
+        delay.delay_ms(5);
+        self.wait_until_idle();
+
+        // Set the clock frequency to 50Hz (default)
+        self.cmd_with_data(spi, Command::PLL_CONTROL, &[0x3C])?;
+
+        // Select internal temperature sensor (default)
+        self.cmd_with_data(spi, Command::TEMPERATURE_CALIBRATION, &[0x00])?;
+
+        // Set Vcom and data interval to 10 (default), border output to white
+        self.cmd_with_data(spi, Command::VCOM_AND_DATA_INTERVAL_SETTING, &[0x77])?;
+
+        // Set S2G and G2S non-overlap periods to 12 (default)
+        self.cmd_with_data(spi, Command::TCON_SETTING, &[0x22])?;
+
+        // Set the real resolution
+        self.send_resolution(spi)?;
+
+        // Set VCOM_DC to -1.5V
+        self.cmd_with_data(spi, Command::VCM_DC_SETTING, &[0x1E])?;
+
+        // This is in all the Waveshare controllers for EPD7in5bc
+        self.cmd_with_data(spi, Command::FLASH_MODE, &[0x03])?;
+
+        self.wait_until_idle();
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> WaveshareThreeColorDisplay<SPI, CS, BUSY, DC, RST>
+    for EPD7in5bc<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn update_color_frame(
+        &mut self,
+        spi: &mut SPI,
+        black: &[u8],
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error> {
+        assert_eq!(black.len(), chromatic.len());
+
+        self.wait_until_idle();
+
+        self.command(spi, Command::DATA_START_TRANSMISSION_1)?;
+
+        for (data_black, data_chromatic) in black.iter().zip(chromatic.iter()) {
+            let mut temp_black = *data_black;
+            let mut temp_chromatic = *data_chromatic;
+
+            for _ in 0..4 {
+                let mut data = if temp_chromatic & 0x80 == 0 {
+                    0x04
+                } else if temp_black & 0x80 == 0 {
+                    0x00
+                } else {
+                    0x03
+                };
+                data <<= 4;
+                temp_black <<= 1;
+                temp_chromatic <<= 1;
+                data |= if temp_chromatic & 0x80 == 0 {
+                    0x04
+                } else if temp_black & 0x80 == 0 {
+                    0x00
+                } else {
+                    0x03
+                };
+                temp_black <<= 1;
+                temp_chromatic <<= 1;
+                self.send_data(spi, &[data])?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Update only the black/white data of the display.
+    ///
+    /// Finish by calling `update_chromatic_frame`.
+    fn update_achromatic_frame(&mut self, spi: &mut SPI, black: &[u8]) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.command(spi, Command::DATA_START_TRANSMISSION_1)?;
+        for byte in black {
+            let mut temp = *byte;
+            for _ in 0..4 {
+                let mut data = if temp & 0x80 == 0 { 0x00 } else { 0x03 };
+                data <<= 4;
+                temp <<= 1;
+                data |= if temp & 0x80 == 0 { 0x00 } else { 0x03 };
+                temp <<= 1;
+                self.send_data(spi, &[data])?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Update only chromatic data of the display.
+    ///
+    /// This data takes precedence over the black/white data.
+    fn update_chromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.command(spi, Command::DATA_START_TRANSMISSION_1)?;
+        for byte in chromatic {
+            let mut temp = *byte;
+            for _ in 0..4 {
+                let mut data = if temp & 0x80 == 0 { 0x04 } else { 0x03 };
+                data <<= 4;
+                temp <<= 1;
+                data |= if temp & 0x80 == 0 { 0x04 } else { 0x03 };
+                temp <<= 1;
+                self.send_data(spi, &[data])?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> WaveshareDisplay<SPI, CS, BUSY, DC, RST>
+    for EPD7in5bc<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn new<DELAY: DelayMs<u8>>(
+        spi: &mut SPI,
+        cs: CS,
+        busy: BUSY,
+        dc: DC,
+        rst: RST,
+        delay: &mut DELAY,
+    ) -> Result<Self, SPI::Error> {
+        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let color = DEFAULT_BACKGROUND_COLOR;
+
+        let mut epd = EPD7in5bc { interface, color };
+
+        epd.init(spi, delay)?;
+
+        Ok(epd)
+    }
+
+    fn wake_up<DELAY: DelayMs<u8>>(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.init(spi, delay)
+    }
+
+    fn sleep(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.command(spi, Command::POWER_OFF)?;
+        self.wait_until_idle();
+        self.cmd_with_data(spi, Command::DEEP_SLEEP, &[0xA5])?;
+        Ok(())
+    }
+
+    fn update_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.command(spi, Command::DATA_START_TRANSMISSION_1)?;
+        for byte in buffer {
+            let mut temp = *byte;
+            for _ in 0..4 {
+                let mut data = if temp & 0x80 == 0 { 0x00 } else { 0x03 };
+                data <<= 4;
+                temp <<= 1;
+                data |= if temp & 0x80 == 0 { 0x00 } else { 0x03 };
+                temp <<= 1;
+                self.send_data(spi, &[data])?;
+            }
+        }
+        Ok(())
+    }
+
+    fn update_partial_frame(
+        &mut self,
+        _spi: &mut SPI,
+        _buffer: &[u8],
+        _x: u32,
+        _y: u32,
+        _width: u32,
+        _height: u32,
+    ) -> Result<(), SPI::Error> {
+        unimplemented!();
+    }
+
+    fn display_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.command(spi, Command::DISPLAY_REFRESH)?;
+        Ok(())
+    }
+
+    fn update_and_display_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.update_frame(spi, buffer)?;
+        self.command(spi, Command::DISPLAY_REFRESH)?;
+        Ok(())
+    }
+
+    fn clear_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.send_resolution(spi)?;
+
+        // The Waveshare controllers all implement clear using 0x33
+        self.command(spi, Command::DATA_START_TRANSMISSION_1)?;
+        self.interface
+            .data_x_times(spi, 0x33, WIDTH / 8 * HEIGHT * 4)?;
+        Ok(())
+    }
+
+    fn set_background_color(&mut self, color: Color) {
+        self.color = color;
+    }
+
+    fn background_color(&self) -> &Color {
+        &self.color
+    }
+
+    fn width(&self) -> u32 {
+        WIDTH
+    }
+
+    fn height(&self) -> u32 {
+        HEIGHT
+    }
+
+    fn set_lut(
+        &mut self,
+        _spi: &mut SPI,
+        _refresh_rate: Option<RefreshLUT>,
+    ) -> Result<(), SPI::Error> {
+        unimplemented!();
+    }
+
+    fn is_busy(&self) -> bool {
+        self.interface.is_busy(IS_BUSY_LOW)
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> EPD7in5bc<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn command(&mut self, spi: &mut SPI, command: Command) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, command)
+    }
+
+    fn send_data(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
+        self.interface.data(spi, data)
+    }
+
+    fn cmd_with_data(
+        &mut self,
+        spi: &mut SPI,
+        command: Command,
+        data: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd_with_data(spi, command, data)
+    }
+
+    fn wait_until_idle(&mut self) {
+        self.interface.wait_until_idle(IS_BUSY_LOW)
+    }
+
+    fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        let w = self.width();
+        let h = self.height();
+
+        self.command(spi, Command::TCON_RESOLUTION)?;
+        self.send_data(spi, &[(w >> 8) as u8])?;
+        self.send_data(spi, &[w as u8])?;
+        self.send_data(spi, &[(h >> 8) as u8])?;
+        self.send_data(spi, &[h as u8])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epd_size() {
+        assert_eq!(WIDTH, 640);
+        assert_eq!(HEIGHT, 384);
+        assert_eq!(DEFAULT_BACKGROUND_COLOR, Color::White);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub mod epd2in9bc;
 pub mod epd4in2;
 pub mod epd7in5;
 pub mod epd7in5_v2;
+pub mod epd7in5bc;
 pub(crate) mod type_a;
 
 /// Includes everything important besides the chosen Display


### PR DESCRIPTION
I'm working on 7in5bc support for aer and since I wanted to try out the colors I added the 7in5bc version. It's mostly copy and paste besides docs and the `fn update_color_frame`. It looks like this is a little different to e.g. the 2in9bc where the update of chromatic and monochromatic part appears to happen separately. 
I still added `update_achromatic_frame` and `update_chromatic_frame` but it adds little value since it's not possible to set e.g. the chromatic part first and then only update the achromatic part (haven't tested if it works the other way around).

![image](https://user-images.githubusercontent.com/5637837/79202817-6ff8ca00-7e3a-11ea-86f9-82256acb16be.png)


