### PR TITLE
Better handling for screen size not divisible by 8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,19 @@ pub mod prelude {
     pub use crate::graphics::{Display, DisplayRotation};
 }
 
+/// Computes the needed buffer length. Takes care of rounding up in case width
+/// is not divisible by 8.
+///
+///  unused
+///  bits        width
+/// <----><------------------------>
+/// [XXXXX210][76543210]...[76543210] ^
+/// [XXXXX210][76543210]...[76543210] | height
+/// [XXXXX210][76543210]...[76543210] v
+pub const fn buffer_len(width: usize, height: usize) -> usize {
+    (width + 7) / 8 * height
+}
+
 use embedded_hal::spi::{Mode, Phase, Polarity};
 
 /// SPI mode -


### PR DESCRIPTION
Screen with width not divisible by 8 require special care when allocating the
buffer and when handling rotation.

Define a function for getting the needed buffer size (round up to next byte).
Change how rotation is done by changing coordinates instead of direct pixel
access.