### PR TITLE
make reset timing device specific

### DIFF
--- a/src/epd1in54/mod.rs
+++ b/src/epd1in54/mod.rs
@@ -94,7 +94,7 @@ where
         spi: &mut SPI,
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.interface.reset(delay);
+        self.interface.reset(delay, 10);
 
         // 3 Databytes:
         // A[7:0]

--- a/src/epd1in54b/mod.rs
+++ b/src/epd1in54b/mod.rs
@@ -52,7 +52,7 @@ where
         spi: &mut SPI,
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.interface.reset(delay);
+        self.interface.reset(delay, 10);
 
         // set the power settings
         self.interface

--- a/src/epd2in13_v2/mod.rs
+++ b/src/epd2in13_v2/mod.rs
@@ -71,7 +71,7 @@ where
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         // HW reset
-        self.interface.reset(delay);
+        self.interface.reset(delay, 10);
 
         if self.refresh == RefreshLUT::QUICK {
             self.set_vcom_register(spi, (-9).vcom())?;

--- a/src/epd2in9/mod.rs
+++ b/src/epd2in9/mod.rs
@@ -94,7 +94,7 @@ where
         spi: &mut SPI,
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.interface.reset(delay);
+        self.interface.reset(delay, 10);
 
         self.wait_until_idle();
 

--- a/src/epd2in9bc/mod.rs
+++ b/src/epd2in9bc/mod.rs
@@ -111,7 +111,7 @@ where
     ) -> Result<(), SPI::Error> {
         // Values taken from datasheet and sample code
 
-        self.interface.reset(delay);
+        self.interface.reset(delay, 10);
 
         // start the booster
         self.interface

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -105,7 +105,7 @@ where
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         // reset the device
-        self.interface.reset(delay);
+        self.interface.reset(delay, 10);
 
         // set the power settings
         self.interface.cmd_with_data(

--- a/src/epd7in5/mod.rs
+++ b/src/epd7in5/mod.rs
@@ -55,7 +55,7 @@ where
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         // Reset the device
-        self.interface.reset(delay);
+        self.interface.reset(delay, 10);
 
         // Set the power settings
         self.cmd_with_data(spi, Command::POWER_SETTING, &[0x37, 0x00])?;

--- a/src/epd7in5_v2/mod.rs
+++ b/src/epd7in5_v2/mod.rs
@@ -59,7 +59,7 @@ where
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         // Reset the device
-        self.interface.reset(delay, 4);
+        self.interface.reset(delay, 2);
 
         // V2 procedure as described here:
         // https://github.com/waveshare/e-Paper/blob/master/RaspberryPi%26JetsonNano/python/lib/waveshare_epd/epd7in5bc_V2.py

--- a/src/epd7in5_v2/mod.rs
+++ b/src/epd7in5_v2/mod.rs
@@ -59,7 +59,7 @@ where
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         // Reset the device
-        self.interface.reset(delay);
+        self.interface.reset(delay, 4);
 
         // V2 procedure as described here:
         // https://github.com/waveshare/e-Paper/blob/master/RaspberryPi%26JetsonNano/python/lib/waveshare_epd/epd7in5bc_V2.py

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -159,13 +159,18 @@ where
     ///
     /// Often used to awake the module from deep sleep. See [EPD4in2::sleep()](EPD4in2::sleep())
     ///
-    /// TODO: Takes at least 400ms of delay alone, can it be shortened?
-    pub(crate) fn reset<DELAY: DelayMs<u8>>(&mut self, delay: &mut DELAY) {
-        let _ = self.rst.set_low();
-        //TODO: why 200ms? (besides being in the arduino version)
-        delay.delay_ms(200);
+    /// The timing of keeping the reset pin low seems to be important and different per device.
+    /// Most displays seem to require keeping it low for 10ms, but the 7in5_v2 only seems to reset
+    /// properly with 4ms
+    pub(crate) fn reset<DELAY: DelayMs<u8>>(&mut self, delay: &mut DELAY, duration: u8) {
         let _ = self.rst.set_high();
-        //TODO: same as 3 lines above
+        delay.delay_ms(10);
+
+        let _ = self.rst.set_low();
+        delay.delay_ms(duration);
+        let _ = self.rst.set_high();
+        //TODO: the upstream libraries always sleep for 200ms here
+        // 10ms works fine with just for the 7in5_v2 but this needs to be validated for other devices
         delay.delay_ms(200);
     }
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -161,7 +161,7 @@ where
     ///
     /// The timing of keeping the reset pin low seems to be important and different per device.
     /// Most displays seem to require keeping it low for 10ms, but the 7in5_v2 only seems to reset
-    /// properly with 4ms
+    /// properly with 2ms
     pub(crate) fn reset<DELAY: DelayMs<u8>>(&mut self, delay: &mut DELAY, duration: u8) {
         let _ = self.rst.set_high();
         delay.delay_ms(10);


### PR DESCRIPTION
reset timings seem to be device specific, trying to reset the 7in5_v2 with timings from other devices does not reset the display.

Timings taken from https://github.com/waveshare/e-Paper/blob/master/RaspberryPi%26JetsonNano/python/lib/waveshare_epd
