### PR TITLE
Further 4in2 improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Added
-
+ - Added QuickRefresh Trait and implemented it for EPD4in2 in #62 (thanks to @David-OConnor)
 
 ### Changed
  - Use specific ParseColorError instead of ()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
  - Use specific ParseColorError instead of ()
+ - EPD4in2: Don't set the resolution (and some more) over and over again (#48)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
  - Added QuickRefresh Trait and implemented it for EPD4in2 in #62 (thanks to @David-OConnor)
+ - Added Epd 2in7 (B) support in #60 (thanks to @pjsier)
 
 ### Changed
  - Use specific ParseColorError instead of ()

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -132,6 +132,15 @@ where
         // 3A 100HZ   29 150Hz 39 200HZ  31 171HZ DEFAULT: 3c 50Hz
         self.cmd_with_data(spi, Command::PLL_CONTROL, &[0x3A])?;
 
+        self.send_resolution(spi)?;
+
+        self.interface
+            .cmd_with_data(spi, Command::VCM_DC_SETTING, &[0x12])?;
+
+        //VBDF 17|D7 VBDW 97  VBDB 57  VBDF F7  VBDW 77  VBDB 37  VBDR B7
+        self.interface
+            .cmd_with_data(spi, Command::VCOM_AND_DATA_INTERVAL_SETTING, &[0x97])?;
+
         self.set_lut(spi, None)?;
 
         self.wait_until_idle();
@@ -201,15 +210,6 @@ where
     fn update_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
         self.wait_until_idle();
         let color_value = self.color.get_byte_value();
-
-        self.send_resolution(spi)?;
-
-        self.interface
-            .cmd_with_data(spi, Command::VCM_DC_SETTING, &[0x12])?;
-
-        //VBDF 17|D7 VBDW 97  VBDB 57  VBDF F7  VBDW 77  VBDB 37  VBDR B7
-        self.interface
-            .cmd_with_data(spi, Command::VCOM_AND_DATA_INTERVAL_SETTING, &[0x97])?;
 
         self.interface
             .cmd(spi, Command::DATA_START_TRANSMISSION_1)?;

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -450,14 +450,6 @@ where
     fn update_old_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
         self.wait_until_idle();
 
-        // todo: Eval if you need these 3 res setting items.
-        self.send_resolution(spi)?;
-        self.interface
-            .cmd_with_data(spi, Command::VCM_DC_SETTING, &[0x12])?;
-        //VBDF 17|D7 VBDW 97  VBDB 57  VBDF F7  VBDW 77  VBDB 37  VBDR B7
-        self.interface
-            .cmd_with_data(spi, Command::VCOM_AND_DATA_INTERVAL_SETTING, &[0x97])?;
-
         self.interface
             .cmd(spi, Command::DATA_START_TRANSMISSION_1)?;
 
@@ -489,14 +481,6 @@ where
         height: u32,
     ) -> Result<(), SPI::Error> {
         self.wait_until_idle();
-
-        // todo: Eval if you need these 3 res setting items.
-        self.send_resolution(spi)?;
-        self.interface
-            .cmd_with_data(spi, Command::VCM_DC_SETTING, &[0x12])?;
-        //VBDF 17|D7 VBDW 97  VBDB 57  VBDF F7  VBDW 77  VBDB 37  VBDR B7
-        self.interface
-            .cmd_with_data(spi, Command::VCOM_AND_DATA_INTERVAL_SETTING, &[0x97])?;
 
         if buffer.len() as u32 != width / 8 * height {
             //TODO: panic!! or sth like that

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -238,6 +238,43 @@ where
 /// and how they will change. This isn't required when using full refreshes.
 ///
 /// (todo: Example ommitted due to CI failures.)
+/// Example:
+///```rust, no_run
+///# use embedded_hal_mock::*;
+///# fn main() -> Result<(), MockError> {
+///# use embedded_graphics::{
+///#   pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+///# };
+///# use epd_waveshare::{epd4in2::*, prelude::*};
+///# use epd_waveshare::graphics::VarDisplay;
+///#
+///# let expectations = [];
+///# let mut spi = spi::Mock::new(&expectations);
+///# let expectations = [];
+///# let cs_pin = pin::Mock::new(&expectations);
+///# let busy_in = pin::Mock::new(&expectations);
+///# let dc = pin::Mock::new(&expectations);
+///# let rst = pin::Mock::new(&expectations);
+///# let mut delay = delay::MockNoop::new();
+///#
+///# // Setup EPD
+///# let mut epd = EPD4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+///let (x, y, frame_width, frame_height) = (20, 40, 80,80);
+///
+///let mut buffer = [DEFAULT_BACKGROUND_COLOR.get_byte_value(); 80 / 8 * 80];
+///let mut display = VarDisplay::new(frame_width, frame_height, &mut buffer);
+///
+///epd.update_partial_old_frame(&mut spi, display.buffer(), x, y, frame_width, frame_height)
+///  .ok();
+///
+///display.clear_buffer(Color::White);
+///// Execute drawing commands here.
+///
+///epd.update_partial_new_frame(&mut spi, display.buffer(), x, y, frame_width, frame_height)
+///  .ok();
+///# Ok(())
+///# }
+///```
 pub trait QuickRefresh<SPI, CS, BUSY, DC, RST>
 where
     SPI: Write<u8>,


### PR DESCRIPTION
@David-OConnor & @mgottschlag:
Is there anything left to do or missing for this from the other 2 issues to round this up?
I copied most of the relevant issues to below:

-----

For #48: I also applied this to the QuickRefresh Trait since its never changed anywhere it should be okay to just apply it once at the beginning like mgottschlag said.

-----
For the new QuickRefresh Trait
 - Is the documentation understandable enough for new users so they unterstand when and how to use it? And how to implement it for others displays?

From:
>I think the doc comment should
>- [ ] state when the user needs to send the old data
>- [ ] explain why this is necessary
>- [ ] maybe give an example?
>
>I think this whole old status/new status stuff is fairly confusing. I can write a patch for that this weekend if you want.

_Originally posted by @mgottschlag in https://github.com/caemor/epd-waveshare/issues/54#issuecomment-719615684_

-----

 Other things from #47:
 > I have experimented with the 4.2 inch e-ink display from waveshare, and the last days I have tried to make quick refresh work. I have observed a number of deficiencies in this library, some of which I do not know how to fix:
> 
>     * [ ]  Newer 4.2" B/W displays seem to require different LUTs for quick refresh.
>       As indicated by a comment below [Ben Krasnow's blog post on quick refresh on this display](https://benkrasnow.blogspot.com/2017/10/fast-partial-refresh-on-42-e-paper.html), there are two versions of the display. I copied the LUTs from the example code for the greyscale Good Display display (does that mean that my B/W display properly supports greyscale? Yay!) and those result in proper black/white pixels, whereas the LUTs in this library currently only result in grey pixels.
>       Link to the example code: http://www.e-paper-display.com/download_detail/downloadsId=1022.html
>       My commit (the old LUTs should probably be accessible though - preferrably not behind a feature gate, but selectable at runtime): [mgottschlag@a24bec5](https://github.com/mgottschlag/epd-waveshare/commit/a24bec5be720c89cedda513a139bc983b0c5e1d0)
> 
>     * [ ]  I am unsure what the point of the "background color" provided by this library is - the documentation is lacking and I think usage the background color as-is is wrong and unusable.
>       My understanding of the background (or "old" frame as called by the documentation is that it allows to choose different LUTs based on what the previous image was. Note that the data is actually required for quick refresh using the LUTs in the example code above, as those completely skip pixels that do not change color!
>       Also, using the wrong background data might cause burn-in issues. According to the internet (I think Ben Krasnows youtube video explained something like this), the applied voltage needs to be on average 0 to prevent charging the display, which causes burn-in. I don't understand the format of the LUTs, but if they are not completely balanced (and inofficial quick refresh LUTs likely are not!), then using the same LUT over and over again causes the display to be charged (whereas only applying voltages during black/white and white/black transitions might cause the effects to cancel each other out and also greatly reduces the number of pixel changes).
>       At least, the library requires updates to the documentation.
> 
>     * [ ]  The library does not provide a method to upload the "old" ("background") data.
>       The official quick refresh LUTs for this display depend on having the old data.
>       My take on this issue: [mgottschlag@dbd065a](https://github.com/mgottschlag/epd-waveshare/commit/dbd065a71595b62147b5a4af8846f1ce1af6e191)

Closes #54 and #47
