### PR TITLE
Add support for epd1in54c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ Cargo.lock
 
 # vscode 
 .vscode/*
+
+# intellij/clion
+.idea/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ epd.update_and_display_frame(&mut spi, &display.buffer())?;
 | [2.13 Inch B/W (A) V2](https://www.waveshare.com/product/2.13inch-e-paper-hat.htm) | Black, White | ✕ | ✔ | ✔  | ✔  |
 | [2.9 Inch B/W (A)](https://www.waveshare.com/product/2.9inch-e-paper-module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 | [1.54 Inch B/W/R (B)](https://www.waveshare.com/product/modules/oleds-lcds/e-paper/1.54inch-e-paper-module-b.htm) | Black, White, Red | ✕ | ✕ | ✔ | ✔ |
+| [1.54 Inch B/W/Y (C)](https://www.waveshare.com/1.54inch-e-paper-c.htm) | Black, White, Yellow | ✕ | ✕ | ✔ | ✔ |
 | [2.9 Inch B/W/R (B/C)](https://www.waveshare.com/product/displays/e-paper/epaper-2/2.9inch-e-paper-module-b.htm) | Black, White, Red | ✕ | ✕ | ✔ | ✔ |
 | [5.65 Inch 7 Color (F)](https://www.waveshare.com/5.65inch-e-paper-module-f.htm) | Black, White, Red, Green, Blue, Yellow, Orange | ✕ | ✕ | ✔ | ✔ |
 | [2.7 Inch 3 Color (B)](https://www.waveshare.com/2.7inch-e-paper-b.htm) | Black, White, Red | ✕ | ✔ | ✔ | ✔ |

--- a/src/epd1in54c/command.rs
+++ b/src/epd1in54c/command.rs
@@ -1,4 +1,4 @@
-//! SPI Commands for the Waveshare 1.54" red E-Ink Display
+//! SPI Commands for the Waveshare 1.54" C red or yellow E-Ink Display
 use crate::traits;
 
 #[allow(dead_code)]

--- a/src/epd1in54c/command.rs
+++ b/src/epd1in54c/command.rs
@@ -1,4 +1,4 @@
-//! SPI Commands for the Waveshare 1.54" C red or yellow E-Ink Display
+//! SPI Commands for the Waveshare 1.54" C yellow E-Ink Display
 use crate::traits;
 
 #[allow(dead_code)]

--- a/src/epd1in54c/command.rs
+++ b/src/epd1in54c/command.rs
@@ -1,0 +1,39 @@
+//! SPI Commands for the Waveshare 1.54" red E-Ink Display
+use crate::traits;
+
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone)]
+pub(crate) enum Command {
+    PANEL_SETTING = 0x00,
+
+    POWER_SETTING = 0x01,
+    POWER_OFF = 0x02,
+    POWER_ON = 0x04,
+    BOOSTER_SOFT_START = 0x06,
+    DEEP_SLEEP = 0x07,
+    DATA_START_TRANSMISSION_1 = 0x10,
+    DISPLAY_REFRESH = 0x12,
+    DATA_START_TRANSMISSION_2 = 0x13,
+
+    LUT_FOR_VCOM = 0x20,
+    LUT_WHITE_TO_WHITE = 0x21,
+    LUT_BLACK_TO_WHITE = 0x22,
+    LUT_WHITE_TO_BLACK = 0x23,
+    LUT_BLACK_TO_BLACK = 0x24,
+
+    PLL_CONTROL = 0x30,
+    TEMPERATURE_SENSOR_COMMAND = 0x40,
+    TEMPERATURE_SENSOR_SELECTION = 0x41,
+    VCOM_AND_DATA_INTERVAL_SETTING = 0x50,
+    RESOLUTION_SETTING = 0x61,
+    VCM_DC_SETTING = 0x82,
+    POWER_SAVING = 0xE3,
+}
+
+impl traits::Command for Command {
+    /// Returns the address of the command
+    fn address(self) -> u8 {
+        self as u8
+    }
+}

--- a/src/epd1in54c/graphics.rs
+++ b/src/epd1in54c/graphics.rs
@@ -3,7 +3,7 @@ use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
 
-/// Full size buffer for use with the 1in54 EPD
+/// Full size buffer for use with the 1in54c EPD
 ///
 /// Can also be manually constructed and be used together with VarDisplay
 pub struct Display1in54c {

--- a/src/epd1in54c/graphics.rs
+++ b/src/epd1in54c/graphics.rs
@@ -1,0 +1,51 @@
+use crate::epd1in54c::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH, NUM_DISPLAY_BITS};
+use crate::graphics::{Display, DisplayRotation};
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::*;
+
+/// Full size buffer for use with the 1in54 EPD
+///
+/// Can also be manually constructed and be used together with VarDisplay
+pub struct Display1in54c {
+    buffer: [u8; NUM_DISPLAY_BITS as usize],
+    rotation: DisplayRotation,
+}
+
+impl Default for Display1in54c {
+    fn default() -> Self {
+        Display1in54c {
+            buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); NUM_DISPLAY_BITS as usize],
+            rotation: DisplayRotation::default(),
+        }
+    }
+}
+
+impl DrawTarget<BinaryColor> for Display1in54c {
+    type Error = core::convert::Infallible;
+
+    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
+        self.draw_helper(WIDTH, HEIGHT, pixel)
+    }
+
+    fn size(&self) -> Size {
+        Size::new(WIDTH, HEIGHT)
+    }
+}
+
+impl Display for Display1in54c {
+    fn buffer(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    fn get_mut_buffer(&mut self) -> &mut [u8] {
+        &mut self.buffer
+    }
+
+    fn set_rotation(&mut self, rotation: DisplayRotation) {
+        self.rotation = rotation;
+    }
+
+    fn rotation(&self) -> DisplayRotation {
+        self.rotation
+    }
+}

--- a/src/epd1in54c/graphics.rs
+++ b/src/epd1in54c/graphics.rs
@@ -1,4 +1,4 @@
-use crate::epd1in54c::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH, NUM_DISPLAY_BITS};
+use crate::epd1in54c::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;

--- a/src/epd1in54c/mod.rs
+++ b/src/epd1in54c/mod.rs
@@ -99,6 +99,8 @@ where
     }
 
     fn update_achromatic_frame(&mut self, spi: &mut SPI, black: &[u8]) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+
         self.interface
             .cmd(spi, Command::DATA_START_TRANSMISSION_1)?;
         self.interface.data(spi, black)?;
@@ -110,6 +112,8 @@ where
         spi: &mut SPI,
         chromatic: &[u8],
     ) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+
         self.interface
             .cmd(spi, Command::DATA_START_TRANSMISSION_2)?;
         self.interface.data(spi, chromatic)?;

--- a/src/epd1in54c/mod.rs
+++ b/src/epd1in54c/mod.rs
@@ -16,15 +16,12 @@ pub const WIDTH: u32 = 152;
 pub const HEIGHT: u32 = 152;
 /// Default Background Color (white)
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
-
-const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
-
 const IS_BUSY_LOW: bool = true;
+const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
 
 use crate::color::Color;
 
 pub(crate) mod command;
-
 use self::command::Command;
 
 #[cfg(feature = "graphics")]
@@ -100,10 +97,8 @@ where
 
     fn update_achromatic_frame(&mut self, spi: &mut SPI, black: &[u8]) -> Result<(), SPI::Error> {
         self.wait_until_idle();
+        self.cmd_with_data(spi, Command::DATA_START_TRANSMISSION_1, black)?;
 
-        self.interface
-            .cmd(spi, Command::DATA_START_TRANSMISSION_1)?;
-        self.interface.data(spi, black)?;
         Ok(())
     }
 
@@ -113,10 +108,8 @@ where
         chromatic: &[u8],
     ) -> Result<(), SPI::Error> {
         self.wait_until_idle();
+        self.cmd_with_data(spi, Command::DATA_START_TRANSMISSION_2, chromatic)?;
 
-        self.interface
-            .cmd(spi, Command::DATA_START_TRANSMISSION_2)?;
-        self.interface.data(spi, chromatic)?;
         Ok(())
     }
 }
@@ -189,8 +182,7 @@ where
         // Clear the chromatic layer
         let color = self.color.get_byte_value();
 
-        self.interface
-            .cmd(spi, Command::DATA_START_TRANSMISSION_2)?;
+        self.command(spi, Command::DATA_START_TRANSMISSION_2)?;
         self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
 
         Ok(())
@@ -228,13 +220,11 @@ where
         let color = DEFAULT_BACKGROUND_COLOR.get_byte_value();
 
         // Clear the black
-        self.interface
-            .cmd(spi, Command::DATA_START_TRANSMISSION_1)?;
+        self.command(spi, Command::DATA_START_TRANSMISSION_1)?;
         self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
 
-        // Clear the red
-        self.interface
-            .cmd(spi, Command::DATA_START_TRANSMISSION_2)?;
+        // Clear the chromatic
+        self.command(spi, Command::DATA_START_TRANSMISSION_2)?;
         self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
 
         Ok(())

--- a/src/epd1in54c/mod.rs
+++ b/src/epd1in54c/mod.rs
@@ -1,0 +1,300 @@
+//! A simple Driver for the Waveshare 1.54" (C) E-Ink Display via SPI
+
+use embedded_hal::{
+    blocking::{delay::*, spi::Write},
+    digital::v2::*,
+};
+
+use crate::interface::DisplayInterface;
+use crate::traits::{
+    InternalWiAdditions, RefreshLUT, WaveshareDisplay, WaveshareThreeColorDisplay,
+};
+
+/// Width of epd1in54 in pixels
+pub const WIDTH: u32 = 152;
+/// Height of epd1in54 in pixels
+pub const HEIGHT: u32 = 152;
+/// Default Background Color (white)
+pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
+
+const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
+
+const IS_BUSY_LOW: bool = true;
+
+use crate::color::Color;
+
+pub(crate) mod command;
+
+use self::command::Command;
+
+#[cfg(feature = "graphics")]
+mod graphics;
+
+#[cfg(feature = "graphics")]
+pub use self::graphics::Display1in54c;
+
+/// EPD1in54c driver
+pub struct EPD1in54c<SPI, CS, BUSY, DC, RST> {
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST>,
+    color: Color,
+}
+
+impl<SPI, CS, BUSY, DC, RST> InternalWiAdditions<SPI, CS, BUSY, DC, RST>
+    for EPD1in54c<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn init<DELAY: DelayMs<u8>>(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        // Based on Reference Program Code from:
+        // https://www.waveshare.com/w/upload/a/ac/1.54inch_e-Paper_Module_C_Specification.pdf
+        // and:
+        // https://github.com/waveshare/e-Paper/blob/master/STM32/STM32-F103ZET6/User/e-Paper/EPD_1in54c.c
+        self.interface.reset(delay, 2);
+
+        // start the booster
+        self.cmd_with_data(spi, Command::BOOSTER_SOFT_START, &[0x17, 0x17, 0x17])?;
+
+        // power on
+        self.command(spi, Command::POWER_ON)?;
+        delay.delay_ms(5);
+        self.wait_until_idle();
+
+        // set the panel settings
+        self.cmd_with_data(spi, Command::PANEL_SETTING, &[0x0f, 0x0d])?;
+
+        // set resolution
+        self.send_resolution(spi)?;
+
+        self.cmd_with_data(spi, Command::VCOM_AND_DATA_INTERVAL_SETTING, &[0x77])?;
+
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> WaveshareThreeColorDisplay<SPI, CS, BUSY, DC, RST>
+    for EPD1in54c<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn update_color_frame(
+        &mut self,
+        spi: &mut SPI,
+        black: &[u8],
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.update_achromatic_frame(spi, black)?;
+        self.update_chromatic_frame(spi, chromatic)
+    }
+
+    fn update_achromatic_frame(&mut self, spi: &mut SPI, black: &[u8]) -> Result<(), SPI::Error> {
+        self.interface
+            .cmd(spi, Command::DATA_START_TRANSMISSION_1)?;
+        self.interface.data(spi, black)?;
+        Ok(())
+    }
+
+    fn update_chromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface
+            .cmd(spi, Command::DATA_START_TRANSMISSION_2)?;
+        self.interface.data(spi, chromatic)?;
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> WaveshareDisplay<SPI, CS, BUSY, DC, RST>
+    for EPD1in54c<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    type DisplayColor = Color;
+    fn new<DELAY: DelayMs<u8>>(
+        spi: &mut SPI,
+        cs: CS,
+        busy: BUSY,
+        dc: DC,
+        rst: RST,
+        delay: &mut DELAY,
+    ) -> Result<Self, SPI::Error> {
+        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let color = DEFAULT_BACKGROUND_COLOR;
+
+        let mut epd = EPD1in54c { interface, color };
+
+        epd.init(spi, delay)?;
+
+        Ok(epd)
+    }
+
+    fn sleep(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+
+        self.command(spi, Command::POWER_OFF)?;
+        self.wait_until_idle();
+        self.cmd_with_data(spi, Command::DEEP_SLEEP, &[0xa5])?;
+
+        Ok(())
+    }
+
+    fn wake_up<DELAY: DelayMs<u8>>(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.init(spi, delay)
+    }
+
+    fn set_background_color(&mut self, color: Color) {
+        self.color = color;
+    }
+
+    fn background_color(&self) -> &Color {
+        &self.color
+    }
+
+    fn width(&self) -> u32 {
+        WIDTH
+    }
+
+    fn height(&self) -> u32 {
+        HEIGHT
+    }
+
+    fn update_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.update_achromatic_frame(spi, buffer)?;
+
+        // Clear the chromatic layer
+        let color = self.color.get_byte_value();
+
+        self.interface
+            .cmd(spi, Command::DATA_START_TRANSMISSION_2)?;
+        self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
+
+        Ok(())
+    }
+
+    #[allow(unused)]
+    fn update_partial_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), SPI::Error> {
+        unimplemented!()
+    }
+
+    fn display_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.command(spi, Command::DISPLAY_REFRESH)?;
+        self.wait_until_idle();
+
+        Ok(())
+    }
+
+    fn update_and_display_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.update_frame(spi, buffer)?;
+        self.display_frame(spi)?;
+
+        Ok(())
+    }
+
+    fn clear_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        let color = DEFAULT_BACKGROUND_COLOR.get_byte_value();
+
+        // Clear the black
+        self.interface
+            .cmd(spi, Command::DATA_START_TRANSMISSION_1)?;
+        self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
+
+        // Clear the red
+        self.interface
+            .cmd(spi, Command::DATA_START_TRANSMISSION_2)?;
+        self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
+
+        Ok(())
+    }
+
+    fn set_lut(
+        &mut self,
+        _spi: &mut SPI,
+        _refresh_rate: Option<RefreshLUT>,
+    ) -> Result<(), SPI::Error> {
+        Ok(())
+    }
+
+    fn is_busy(&self) -> bool {
+        self.interface.is_busy(IS_BUSY_LOW)
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> EPD1in54c<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn command(&mut self, spi: &mut SPI, command: Command) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, command)
+    }
+
+    fn send_data(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
+        self.interface.data(spi, data)
+    }
+
+    fn cmd_with_data(
+        &mut self,
+        spi: &mut SPI,
+        command: Command,
+        data: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd_with_data(spi, command, data)
+    }
+
+    fn wait_until_idle(&mut self) {
+        self.interface.wait_until_idle(IS_BUSY_LOW)
+    }
+
+    fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        let w = self.width();
+        let h = self.height();
+
+        self.command(spi, Command::RESOLUTION_SETTING)?;
+
+        // | D7 | D6 | D5 | D4 | D3 | D2 | D1 | D0 |
+        // |       HRES[7:3]        |  0 |  0 |  0 |
+        self.send_data(spi, &[(w as u8) & 0b1111_1000])?;
+        // | D7 | D6 | D5 | D4 | D3 | D2 | D1 |      D0 |
+        // |  - |  - |  - |  - |  - |  - |  - | VRES[8] |
+        self.send_data(spi, &[(w >> 8) as u8])?;
+        // | D7 | D6 | D5 | D4 | D3 | D2 | D1 |      D0 |
+        // |                  VRES[7:0]                 |
+        // Specification shows C/D is zero while sending the last byte,
+        // but upstream code does not implement it like that. So for now
+        // we follow upstream code.
+        self.send_data(spi, &[h as u8])
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ mod interface;
 
 pub mod epd1in54;
 pub mod epd1in54b;
+pub mod epd1in54c;
 pub mod epd2in13_v2;
 pub mod epd2in7b;
 pub mod epd2in9;


### PR DESCRIPTION
I added support for the EPD 1in54 e-Paper module C display. I based this off the existing code base and the code from the [official  driver](https://github.com/waveshare/e-Paper/blob/master/STM32/STM32-F103ZET6/User/e-Paper/EPD_1in54c.c). I also used the documentation from the [waveshare wiki](https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_(C)).

I also tried setting LUT values from the module B variant, but that didn't seem to give a correct result. So for now setting the LUT values is not supported.

This is basically my first time working with embedded systems, so let me know if I made any mistakes.