### PR TITLE
Added support for the 7.5 inch HD display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
  - Added QuickRefresh Trait and implemented it for EPD4in2 in #62 (thanks to @David-OConnor)
  - Added Epd 2in7 (B) support in #60 (thanks to @pjsier)
+ - Added Epd 7in5 HD support
 
 ### Changed
  - Use specific ParseColorError instead of ()

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ epd.update_and_display_frame(&mut spi, &display.buffer())?;
 
 | Device (with Link) | Colors | Flexible Display | Partial Refresh | Supported | Tested |
 | :---: | --- | :---: | :---: | :---: | :---: |
+| [7.5 Inch B/W HD (A)](https://www.waveshare.com/product/displays/e-paper/epaper-1/7.5inch-hd-e-paper-hat.htm) | Black, White | ✕ | ✕ | ✔ | ✔ |
 | [7.5 Inch B/W V2 (A)](https://www.waveshare.com/product/7.5inch-e-paper-hat.htm) [[1](#1-75-inch-bw-v2-a)] | Black, White | ✕ | ✕ | ✔ | ✔ |
 | [7.5 Inch B/W (A)](https://www.waveshare.com/product/7.5inch-e-paper-hat.htm) | Black, White | ✕ | ✕ | ✔ | ✔ |
 | [4.2 Inch B/W (A)](https://www.waveshare.com/product/4.2inch-e-paper-module.htm) | Black, White | ✕ | Not officially [[2](#2-42-inch-e-ink-blackwhite---partial-refresh)] | ✔ | ✔ |

--- a/src/epd7in5_hd/command.rs
+++ b/src/epd7in5_hd/command.rs
@@ -152,7 +152,8 @@ mod tests {
 
     #[test]
     fn command_addr() {
-        // assert_eq!(Command::PANEL_SETTING.address(), 0x00);
-        // assert_eq!(Command::DISPLAY_REFRESH.address(), 0x12);
+        assert_eq!(Command::MASTER_ACTIVATION.address(), 0x20);
+        assert_eq!(Command::SW_RESET.address(), 0x12);
+        assert_eq!(Command::DISPLAY_UPDATE_CONTROL_2.address(), 0x22);
     }
 }

--- a/src/epd7in5_hd/command.rs
+++ b/src/epd7in5_hd/command.rs
@@ -11,131 +11,131 @@ use crate::traits;
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
 pub(crate) enum Command {
-    DRIVER_OUTPUT_CONTROL = 0x01,
+    DriverOutputControl = 0x01,
 
     /// Set gate driving voltage
-    GATE_DRIVING_VOLTAGE_CONTROL = 0x03,
+    GateDrivingVoltageControl = 0x03,
 
     /// Set source driving voltage
-    SOURCE_DRIVING_VOLTAGE_CONTROL = 0x04,
+    SourceDrivingVoltageControl = 0x04,
 
-    SOFT_START = 0x0C,
+    SoftStart = 0x0C,
 
     /// Set the scanning start position of the gate driver.
     /// The valid range is from 0 to 679.
-    GATE_SCAN_START_POSITION = 0x0F,
+    GateScanStartPosition = 0x0F,
 
     /// Deep sleep mode control
-    DEEP_SLEEP = 0x10,
+    DeepSleep = 0x10,
 
     /// Define data entry sequence
-    DATA_ENTRY = 0x11,
+    DataEntry = 0x11,
 
     /// resets the commands and parameters to their S/W Reset default values except R10h-Deep Sleep Mode.
     /// During operation, BUSY pad will output high.
     /// Note: RAM are unaffected by this command.
-    SW_RESET = 0x12,
+    SwReset = 0x12,
 
     /// After this command initiated, HV Ready detection starts.
     /// BUSY pad will output high during detection.
     /// The detection result can be read from the Status Bit Read (Command 0x2F).
-    HV_READY_DETECTION = 0x14,
+    HvReadyDetection = 0x14,
 
     /// After this command initiated, VCI detection starts.
     /// BUSY pad will output high during detection.
     /// The detection result can be read from the Status Bit Read (Command 0x2F).
-    VCI_DETECTION = 0x15,
+    VciDetection = 0x15,
 
     /// Temperature Sensor Selection
-    TEMPERATURE_SENSOR_CONTROL = 0x18,
+    TemperatureSensorControl = 0x18,
 
     /// Write to temperature register
-    TEMPERATURE_SENSOR_WRITE = 0x1A,
+    TemperatureSensorWrite = 0x1A,
 
     /// Read from temperature register
-    TEMPERATURE_SENSOR_READ = 0x1B,
+    TemperatureSensorRead = 0x1B,
 
     /// Write Command to External temperature sensor.
-    TEMPERATURE_SENSOR_WRITE_EXTERNAL = 0x1C,
+    TemperatureSensorWriteExternal = 0x1C,
 
     /// Activate Display Update Sequence
-    MASTER_ACTIVATION = 0x20,
+    MasterActivation = 0x20,
 
     /// RAM content option for Display Update
-    DISPLAY_UPDATE_CONTROL_1 = 0x21,
+    DisplayUpdateControl1 = 0x21,
 
     /// Display Update Sequence Option
-    DISPLAY_UPDATE_CONTROL_2 = 0x22,
+    DisplayUpdateControl2 = 0x22,
 
     /// After this command, data entries will be written into the BW RAM until another command is written
-    WRITE_RAM_BW = 0x24,
+    WriteRamBw = 0x24,
 
     /// After this command, data entries will be written into the RED RAM until another command is written
-    WRITE_RAM_RED = 0x26,
+    WriteRamRed = 0x26,
 
     /// Fetch data from RAM
-    READ_RAM = 0x27,
+    ReadRam = 0x27,
 
     /// Enter VCOM sensing conditions
-    VCOM_SENSE = 0x28,
+    VcomSense = 0x28,
 
     /// Enter VCOM sensing conditions
-    VCOM_SENSE_DURATION = 0x29,
+    VcomSenseDuration = 0x29,
 
     /// Program VCOM register into OTP
-    VCOM_PROGRAM_OTP = 0x2A,
+    VcomProgramOtp = 0x2A,
 
     /// Reduces a glitch when ACVCOM is toggled
-    VCOM_CONTROL = 0x2B,
+    VcomControl = 0x2B,
 
     /// Write VCOM register from MCU interface
-    VCOM_WRITE = 0x2C,
+    VcomWrite = 0x2C,
 
     /// Read Register for Display Option
-    OTP_READ = 0x2D,
+    OtpRead = 0x2D,
 
     /// CRC calculation command for OTP content validation
-    CRC_CALCULATION = 0x34,
+    CrcCalculation = 0x34,
 
     /// CRC Status Read
-    CRC_READ = 0x35,
+    CrcRead = 0x35,
 
     /// Program OTP Selection according to the OTP Selection Control
-    PROGRAM_SELECTION = 0x36,
+    ProgramSelection = 0x36,
 
     /// Write Register for Display Option
-    DISPLAY_OPTION_WRITE = 0x37,
+    DisplayOptionWrite = 0x37,
 
     /// Write register for User ID
-    USER_ID_WRITE = 0x38,
+    UserIdWrite = 0x38,
 
     /// Select border waveform for VBD
-    VBD_CONTROL = 0x3C,
+    VbdControl = 0x3C,
 
     /// Read RAM Option
-    READ_RAM_OPTION = 0x41,
+    ReadRamOption = 0x41,
 
     /// Specify the start/end positions of the window address in the X direction by an address unit for RAM
-    SET_RAM_X_START_END = 0x44,
+    SetRamXStartEnd = 0x44,
 
     /// Specify the start/end positions of the window address in the Y direction by an address unit for RAM
-    SET_RAM_Y_START_END = 0x45,
+    SetRamYStartEnd = 0x45,
 
     /// Auto write RED RAM for regular pattern
-    AUTO_WRITE_RED = 0x46,
+    AutoWriteRed = 0x46,
 
     /// Auto write B/W RAM for regular pattern
-    AUTO_WRITE_BW = 0x47,
+    AutoWriteBw = 0x47,
 
     /// Make initial settings for the RAM X address in the address counter (AC)
-    SET_RAM_X_AC = 0x4E,
+    SetRamXAc = 0x4E,
 
     /// Make initial settings for the RAM Y address in the address counter (AC)
-    SET_RAM_Y_AC = 0x4F,
+    SetRamYAc = 0x4F,
 
     /// This command is an empty command; it does not have any effect on the display module.
     /// However, it can be used to terminate Frame Memory Write or Read Commands.
-    NOP = 0x7F,
+    Nop = 0x7F,
 }
 
 impl traits::Command for Command {
@@ -152,8 +152,8 @@ mod tests {
 
     #[test]
     fn command_addr() {
-        assert_eq!(Command::MASTER_ACTIVATION.address(), 0x20);
-        assert_eq!(Command::SW_RESET.address(), 0x12);
-        assert_eq!(Command::DISPLAY_UPDATE_CONTROL_2.address(), 0x22);
+        assert_eq!(Command::MasterActivation.address(), 0x20);
+        assert_eq!(Command::SwReset.address(), 0x12);
+        assert_eq!(Command::DisplayUpdateControl2.address(), 0x22);
     }
 }

--- a/src/epd7in5_hd/command.rs
+++ b/src/epd7in5_hd/command.rs
@@ -1,0 +1,158 @@
+//! SPI Commands for the Waveshare 7.5" E-Ink Display
+
+use crate::traits;
+
+/// EPD7in5 commands
+///
+/// Should rarely (never?) be needed directly.
+///
+/// For more infos about the addresses and what they are doing look into the PDFs.
+#[allow(dead_code)]
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone)]
+pub(crate) enum Command {
+    DRIVER_OUTPUT_CONTROL = 0x01,
+
+    /// Set gate driving voltage
+    GATE_DRIVING_VOLTAGE_CONTROL = 0x03,
+
+    /// Set source driving voltage
+    SOURCE_DRIVING_VOLTAGE_CONTROL = 0x04,
+
+    SOFT_START = 0x0C,
+
+    /// Set the scanning start position of the gate driver.
+    /// The valid range is from 0 to 679.
+    GATE_SCAN_START_POSITION = 0x0F,
+
+    /// Deep sleep mode control
+    DEEP_SLEEP = 0x10,
+
+    /// Define data entry sequence
+    DATA_ENTRY = 0x11,
+
+    /// resets the commands and parameters to their S/W Reset default values except R10h-Deep Sleep Mode.
+    /// During operation, BUSY pad will output high.
+    /// Note: RAM are unaffected by this command.
+    SW_RESET = 0x12,
+
+    /// After this command initiated, HV Ready detection starts.
+    /// BUSY pad will output high during detection.
+    /// The detection result can be read from the Status Bit Read (Command 0x2F).
+    HV_READY_DETECTION = 0x14,
+
+    /// After this command initiated, VCI detection starts.
+    /// BUSY pad will output high during detection.
+    /// The detection result can be read from the Status Bit Read (Command 0x2F).
+    VCI_DETECTION = 0x15,
+
+    /// Temperature Sensor Selection
+    TEMPERATURE_SENSOR_CONTROL = 0x18,
+
+    /// Write to temperature register
+    TEMPERATURE_SENSOR_WRITE = 0x1A,
+
+    /// Read from temperature register
+    TEMPERATURE_SENSOR_READ = 0x1B,
+
+    /// Write Command to External temperature sensor.
+    TEMPERATURE_SENSOR_WRITE_EXTERNAL = 0x1C,
+
+    /// Activate Display Update Sequence
+    MASTER_ACTIVATION = 0x20,
+
+    /// RAM content option for Display Update
+    DISPLAY_UPDATE_CONTROL_1 = 0x21,
+
+    /// Display Update Sequence Option
+    DISPLAY_UPDATE_CONTROL_2 = 0x22,
+
+    /// After this command, data entries will be written into the BW RAM until another command is written
+    WRITE_RAM_BW = 0x24,
+
+    /// After this command, data entries will be written into the RED RAM until another command is written
+    WRITE_RAM_RED = 0x26,
+
+    /// Fetch data from RAM
+    READ_RAM = 0x27,
+
+    /// Enter VCOM sensing conditions
+    VCOM_SENSE = 0x28,
+
+    /// Enter VCOM sensing conditions
+    VCOM_SENSE_DURATION = 0x29,
+
+    /// Program VCOM register into OTP
+    VCOM_PROGRAM_OTP = 0x2A,
+
+    /// Reduces a glitch when ACVCOM is toggled
+    VCOM_CONTROL = 0x2B,
+
+    /// Write VCOM register from MCU interface
+    VCOM_WRITE = 0x2C,
+
+    /// Read Register for Display Option
+    OTP_READ = 0x2D,
+
+    /// CRC calculation command for OTP content validation
+    CRC_CALCULATION = 0x34,
+
+    /// CRC Status Read
+    CRC_READ = 0x35,
+
+    /// Program OTP Selection according to the OTP Selection Control
+    PROGRAM_SELECTION = 0x36,
+
+    /// Write Register for Display Option
+    DISPLAY_OPTION_WRITE = 0x37,
+
+    /// Write register for User ID
+    USER_ID_WRITE = 0x38,
+
+    /// Select border waveform for VBD
+    VBD_CONTROL = 0x3C,
+
+    /// Read RAM Option
+    READ_RAM_OPTION = 0x41,
+
+    /// Specify the start/end positions of the window address in the X direction by an address unit for RAM
+    SET_RAM_X_START_END = 0x44,
+
+    /// Specify the start/end positions of the window address in the Y direction by an address unit for RAM
+    SET_RAM_Y_START_END = 0x45,
+
+    /// Auto write RED RAM for regular pattern
+    AUTO_WRITE_RED = 0x46,
+
+    /// Auto write B/W RAM for regular pattern
+    AUTO_WRITE_BW = 0x47,
+
+    /// Make initial settings for the RAM X address in the address counter (AC)
+    SET_RAM_X_AC = 0x4E,
+
+    /// Make initial settings for the RAM Y address in the address counter (AC)
+    SET_RAM_Y_AC = 0x4F,
+
+    /// This command is an empty command; it does not have any effect on the display module.
+    /// However, it can be used to terminate Frame Memory Write or Read Commands.
+    NOP = 0x7F,
+}
+
+impl traits::Command for Command {
+    /// Returns the address of the command
+    fn address(self) -> u8 {
+        self as u8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::Command as CommandTrait;
+
+    #[test]
+    fn command_addr() {
+        // assert_eq!(Command::PANEL_SETTING.address(), 0x00);
+        // assert_eq!(Command::DISPLAY_REFRESH.address(), 0x12);
+    }
+}

--- a/src/epd7in5_hd/graphics.rs
+++ b/src/epd7in5_hd/graphics.rs
@@ -1,0 +1,149 @@
+use crate::epd7in5_hd::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
+use crate::graphics::{Display, DisplayRotation};
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::*;
+
+/// Full size buffer for use with the 7in5 EPD
+///
+/// Can also be manually constructed:
+/// `buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); WIDTH / 8 * HEIGHT]`
+pub struct Display7in5 {
+    buffer: [u8; WIDTH as usize * HEIGHT as usize / 8],
+    rotation: DisplayRotation,
+}
+
+impl Default for Display7in5 {
+    fn default() -> Self {
+        Display7in5 {
+            buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value();
+                WIDTH as usize * HEIGHT as usize / 8],
+            rotation: DisplayRotation::default(),
+        }
+    }
+}
+
+impl DrawTarget<BinaryColor> for Display7in5 {
+    type Error = core::convert::Infallible;
+
+    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
+        self.draw_helper(WIDTH, HEIGHT, pixel)
+    }
+
+    fn size(&self) -> Size {
+        Size::new(WIDTH, HEIGHT)
+    }
+}
+
+impl Display for Display7in5 {
+    fn buffer(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    fn get_mut_buffer(&mut self) -> &mut [u8] {
+        &mut self.buffer
+    }
+
+    fn set_rotation(&mut self, rotation: DisplayRotation) {
+        self.rotation = rotation;
+    }
+
+    fn rotation(&self) -> DisplayRotation {
+        self.rotation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color::{Black, Color};
+    use crate::epd7in5_hd;
+    use crate::graphics::{Display, DisplayRotation};
+    use embedded_graphics::{primitives::Line, style::PrimitiveStyle};
+
+    // test buffer length
+    #[test]
+    fn graphics_size() {
+        let display = Display7in5::default();
+        assert_eq!(display.buffer().len(), 58080);
+    }
+
+    // test default background color on all bytes
+    #[test]
+    fn graphics_default() {
+        let display = Display7in5::default();
+        for &byte in display.buffer() {
+            assert_eq!(byte, epd7in5_hd::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+
+    #[test]
+    fn graphics_rotation_0() {
+        let mut display = Display7in5::default();
+
+        let _ = Line::new(Point::new(0, 0), Point::new(7, 0))
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .draw(&mut display);
+
+        let buffer = display.buffer();
+
+        assert_eq!(buffer[0], Color::Black.get_byte_value());
+
+        for &byte in buffer.iter().skip(1) {
+            assert_eq!(byte, epd7in5_hd::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+
+    #[test]
+    fn graphics_rotation_90() {
+        let mut display = Display7in5::default();
+        display.set_rotation(DisplayRotation::Rotate90);
+
+        let _ = Line::new(Point::new(0, 792), Point::new(0, 799))
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .draw(&mut display);
+
+        let buffer = display.buffer();
+
+        assert_eq!(buffer[0], Color::Black.get_byte_value());
+
+        for &byte in buffer.iter().skip(1) {
+            assert_eq!(byte, epd7in5_hd::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+
+    #[test]
+    fn graphics_rotation_180() {
+        let mut display = Display7in5::default();
+        display.set_rotation(DisplayRotation::Rotate180);
+
+        let _ = Line::new(Point::new(792, 479), Point::new(799, 479))
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .draw(&mut display);
+
+        let buffer = display.buffer();
+
+        assert_eq!(buffer[0], Color::Black.get_byte_value());
+
+        for &byte in buffer.iter().skip(1) {
+            assert_eq!(byte, epd7in5_hd::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+
+    #[test]
+    fn graphics_rotation_270() {
+        let mut display = Display7in5::default();
+        display.set_rotation(DisplayRotation::Rotate270);
+
+        let _ = Line::new(Point::new(479, 0), Point::new(479, 7))
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .draw(&mut display);
+
+        let buffer = display.buffer();
+
+        assert_eq!(buffer[0], Color::Black.get_byte_value());
+
+        for &byte in buffer.iter().skip(1) {
+            assert_eq!(byte, epd7in5_hd::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+}

--- a/src/epd7in5_hd/graphics.rs
+++ b/src/epd7in5_hd/graphics.rs
@@ -98,7 +98,7 @@ mod tests {
         let mut display = Display7in5::default();
         display.set_rotation(DisplayRotation::Rotate90);
 
-        let _ = Line::new(Point::new(0, 792), Point::new(0, 799))
+        let _ = Line::new(Point::new(0, 872), Point::new(0, 879))
             .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
@@ -116,7 +116,7 @@ mod tests {
         let mut display = Display7in5::default();
         display.set_rotation(DisplayRotation::Rotate180);
 
-        let _ = Line::new(Point::new(792, 479), Point::new(799, 479))
+        let _ = Line::new(Point::new(872, 527), Point::new(879, 527))
             .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
@@ -134,7 +134,7 @@ mod tests {
         let mut display = Display7in5::default();
         display.set_rotation(DisplayRotation::Rotate270);
 
-        let _ = Line::new(Point::new(479, 0), Point::new(479, 7))
+        let _ = Line::new(Point::new(527, 0), Point::new(527, 7))
             .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -66,34 +66,34 @@ where
         // https://www.waveshare.com/w/upload/2/27/7inch_HD_e-Paper_Specification.pdf
 
         self.wait_until_idle();
-        self.command(spi, Command::SW_RESET)?;
+        self.command(spi, Command::SwReset)?;
         self.wait_until_idle();
 
-        self.cmd_with_data(spi, Command::AUTO_WRITE_RED, &[0xF7])?;
+        self.cmd_with_data(spi, Command::AutoWriteRed, &[0xF7])?;
         self.wait_until_idle();
-        self.cmd_with_data(spi, Command::AUTO_WRITE_BW, &[0xF7])?;
-        self.wait_until_idle();
-
-        self.cmd_with_data(spi, Command::SOFT_START, &[0xAE, 0xC7, 0xC3, 0xC0, 0x40])?;
-
-        self.cmd_with_data(spi, Command::DRIVER_OUTPUT_CONTROL, &[0xAF, 0x02, 0x01])?;
-
-        self.cmd_with_data(spi, Command::DATA_ENTRY, &[0x01])?;
-
-        self.cmd_with_data(spi, Command::SET_RAM_X_START_END, &[0x00, 0x00, 0x6F, 0x03])?;
-        self.cmd_with_data(spi, Command::SET_RAM_Y_START_END, &[0xAF, 0x02, 0x00, 0x00])?;
-
-        self.cmd_with_data(spi, Command::VBD_CONTROL, &[0x05])?;
-
-        self.cmd_with_data(spi, Command::TEMPERATURE_SENSOR_CONTROL, &[0x80])?;
-
-        self.cmd_with_data(spi, Command::DISPLAY_UPDATE_CONTROL_2, &[0xB1])?;
-
-        self.command(spi, Command::MASTER_ACTIVATION)?;
+        self.cmd_with_data(spi, Command::AutoWriteBw, &[0xF7])?;
         self.wait_until_idle();
 
-        self.cmd_with_data(spi, Command::SET_RAM_X_AC, &[0x00, 0x00])?;
-        self.cmd_with_data(spi, Command::SET_RAM_Y_AC, &[0x00, 0x00])?;
+        self.cmd_with_data(spi, Command::SoftStart, &[0xAE, 0xC7, 0xC3, 0xC0, 0x40])?;
+
+        self.cmd_with_data(spi, Command::DriverOutputControl, &[0xAF, 0x02, 0x01])?;
+
+        self.cmd_with_data(spi, Command::DataEntry, &[0x01])?;
+
+        self.cmd_with_data(spi, Command::SetRamXStartEnd, &[0x00, 0x00, 0x6F, 0x03])?;
+        self.cmd_with_data(spi, Command::SetRamYStartEnd, &[0xAF, 0x02, 0x00, 0x00])?;
+
+        self.cmd_with_data(spi, Command::VbdControl, &[0x05])?;
+
+        self.cmd_with_data(spi, Command::TemperatureSensorControl, &[0x80])?;
+
+        self.cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xB1])?;
+
+        self.command(spi, Command::MasterActivation)?;
+        self.wait_until_idle();
+
+        self.cmd_with_data(spi, Command::SetRamXAc, &[0x00, 0x00])?;
+        self.cmd_with_data(spi, Command::SetRamYAc, &[0x00, 0x00])?;
 
         Ok(())
     }
@@ -137,15 +137,15 @@ where
 
     fn sleep(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
         self.wait_until_idle();
-        self.cmd_with_data(spi, Command::DEEP_SLEEP, &[0x01])?;
+        self.cmd_with_data(spi, Command::DeepSleep, &[0x01])?;
         Ok(())
     }
 
     fn update_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
         self.wait_until_idle();
-        self.cmd_with_data(spi, Command::SET_RAM_Y_AC, &[0x00, 0x00])?;
-        self.cmd_with_data(spi, Command::WRITE_RAM_BW, buffer)?;
-        self.cmd_with_data(spi, Command::DISPLAY_UPDATE_CONTROL_2, &[0xF7])?;
+        self.cmd_with_data(spi, Command::SetRamYAc, &[0x00, 0x00])?;
+        self.cmd_with_data(spi, Command::WriteRamBw, buffer)?;
+        self.cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xF7])?;
         Ok(())
     }
 
@@ -162,7 +162,7 @@ where
     }
 
     fn display_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
-        self.command(spi, Command::MASTER_ACTIVATION)?;
+        self.command(spi, Command::MasterActivation)?;
         self.wait_until_idle();
         Ok(())
     }
@@ -178,16 +178,16 @@ where
         let background_color_byte = self.color.get_byte_value();
 
         self.wait_until_idle();
-        self.cmd_with_data(spi, Command::SET_RAM_Y_AC, &[0x00, 0x00])?;
+        self.cmd_with_data(spi, Command::SetRamYAc, &[0x00, 0x00])?;
 
-        for cmd in &[Command::WRITE_RAM_BW, Command::WRITE_RAM_RED] {
+        for cmd in &[Command::WriteRamBw, Command::WriteRamRed] {
             self.command(spi, *cmd)?;
             self.interface
                 .data_x_times(spi, background_color_byte, pixel_count)?;
         }
 
-        self.cmd_with_data(spi, Command::DISPLAY_UPDATE_CONTROL_2, &[0xF7])?;
-        self.command(spi, Command::MASTER_ACTIVATION)?;
+        self.cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xF7])?;
+        self.command(spi, Command::MasterActivation)?;
         self.wait_until_idle();
         Ok(())
     }

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -36,7 +36,7 @@ const IS_BUSY_LOW: bool = false;
 
 /// EPD7in5 (HD) driver
 ///
-pub struct EPD7in5<SPI, CS, BUSY, DC, RST> {
+pub struct Epd7in5<SPI, CS, BUSY, DC, RST> {
     /// Connection Interface
     interface: DisplayInterface<SPI, CS, BUSY, DC, RST>,
     /// Background Color
@@ -44,7 +44,7 @@ pub struct EPD7in5<SPI, CS, BUSY, DC, RST> {
 }
 
 impl<SPI, CS, BUSY, DC, RST> InternalWiAdditions<SPI, CS, BUSY, DC, RST>
-    for EPD7in5<SPI, CS, BUSY, DC, RST>
+    for Epd7in5<SPI, CS, BUSY, DC, RST>
 where
     SPI: Write<u8>,
     CS: OutputPin,
@@ -100,7 +100,7 @@ where
 }
 
 impl<SPI, CS, BUSY, DC, RST> WaveshareDisplay<SPI, CS, BUSY, DC, RST>
-    for EPD7in5<SPI, CS, BUSY, DC, RST>
+    for Epd7in5<SPI, CS, BUSY, DC, RST>
 where
     SPI: Write<u8>,
     CS: OutputPin,
@@ -120,7 +120,7 @@ where
         let interface = DisplayInterface::new(cs, busy, dc, rst);
         let color = DEFAULT_BACKGROUND_COLOR;
 
-        let mut epd = EPD7in5 { interface, color };
+        let mut epd = Epd7in5 { interface, color };
 
         epd.init(spi, delay)?;
 
@@ -221,7 +221,7 @@ where
     }
 }
 
-impl<SPI, CS, BUSY, DC, RST> EPD7in5<SPI, CS, BUSY, DC, RST>
+impl<SPI, CS, BUSY, DC, RST> Epd7in5<SPI, CS, BUSY, DC, RST>
 where
     SPI: Write<u8>,
     CS: OutputPin,

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -1,0 +1,275 @@
+//! A simple Driver for the Waveshare 7.5" E-Ink Display (HD) via SPI
+//!
+//! # References
+//!
+//! - [Datasheet](https://www.waveshare.com/w/upload/2/27/7inch_HD_e-Paper_Specification.pdf)
+//! - [Waveshare Python driver](https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py)
+//!
+use embedded_hal::{
+    blocking::{delay::*, spi::Write},
+    digital::v2::{InputPin, OutputPin},
+};
+
+use crate::color::Color;
+use crate::interface::DisplayInterface;
+use crate::traits::{InternalWiAdditions, RefreshLUT, WaveshareDisplay};
+
+pub(crate) mod command;
+use self::command::Command;
+
+#[cfg(feature = "graphics")]
+mod graphics;
+#[cfg(feature = "graphics")]
+pub use self::graphics::Display7in5;
+
+/// Width of the display
+pub const WIDTH: u32 = 880;
+/// Height of the display
+pub const HEIGHT: u32 = 528;
+/// Default Background Color
+pub const DEFAULT_BACKGROUND_COLOR: Color = Color::Black; // Inverted for HD (0xFF = White)
+const IS_BUSY_LOW: bool = false;
+
+/// EPD7in5 (HD) driver
+///
+pub struct EPD7in5<SPI, CS, BUSY, DC, RST> {
+    /// Connection Interface
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST>,
+    /// Background Color
+    color: Color,
+}
+
+impl<SPI, CS, BUSY, DC, RST> InternalWiAdditions<SPI, CS, BUSY, DC, RST>
+    for EPD7in5<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn init<DELAY: DelayMs<u8>>(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        // Reset the device
+        self.interface.reset(delay, 2);
+
+        // HD procedure as described here:
+        // https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py
+        // and as per specs:
+        // https://www.waveshare.com/w/upload/2/27/7inch_HD_e-Paper_Specification.pdf
+
+        self.wait_until_idle();
+        self.command(spi, Command::SW_RESET)?;
+        self.wait_until_idle();
+
+        self.cmd_with_data(spi, Command::AUTO_WRITE_RED, &[0xF7])?;
+        self.wait_until_idle();
+        self.cmd_with_data(spi, Command::AUTO_WRITE_BW, &[0xF7])?;
+        self.wait_until_idle();
+
+        self.cmd_with_data(spi, Command::SOFT_START, &[0xAE, 0xC7, 0xC3, 0xC0, 0x40])?;
+
+        self.cmd_with_data(spi, Command::DRIVER_OUTPUT_CONTROL, &[0xAF, 0x02, 0x01])?;
+
+        self.cmd_with_data(spi, Command::DATA_ENTRY, &[0x01])?;
+
+        self.cmd_with_data(spi, Command::SET_RAM_X_START_END, &[0x00, 0x00, 0x6F, 0x03])?;
+        self.cmd_with_data(spi, Command::SET_RAM_Y_START_END, &[0xAF, 0x02, 0x00, 0x00])?;
+
+        self.cmd_with_data(spi, Command::VBD_CONTROL, &[0x05])?;
+
+        self.cmd_with_data(spi, Command::TEMPERATURE_SENSOR_CONTROL, &[0x80])?;
+
+        self.cmd_with_data(spi, Command::DISPLAY_UPDATE_CONTROL_2, &[0xB1])?;
+
+        self.command(spi, Command::MASTER_ACTIVATION)?;
+        self.wait_until_idle();
+
+        self.cmd_with_data(spi, Command::SET_RAM_X_AC, &[0x00, 0x00])?;
+        self.cmd_with_data(spi, Command::SET_RAM_Y_AC, &[0x00, 0x00])?;
+
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> WaveshareDisplay<SPI, CS, BUSY, DC, RST>
+    for EPD7in5<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    type DisplayColor = Color;
+    fn new<DELAY: DelayMs<u8>>(
+        spi: &mut SPI,
+        cs: CS,
+        busy: BUSY,
+        dc: DC,
+        rst: RST,
+        delay: &mut DELAY,
+    ) -> Result<Self, SPI::Error> {
+        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let color = DEFAULT_BACKGROUND_COLOR;
+
+        let mut epd = EPD7in5 { interface, color };
+
+        epd.init(spi, delay)?;
+
+        Ok(epd)
+    }
+
+    fn wake_up<DELAY: DelayMs<u8>>(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.init(spi, delay)
+    }
+
+    fn sleep(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.cmd_with_data(spi, Command::DEEP_SLEEP, &[0x01])?;
+        Ok(())
+    }
+
+    fn update_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.cmd_with_data(spi, Command::SET_RAM_Y_AC, &[0x00, 0x00])?;
+        self.cmd_with_data(spi, Command::WRITE_RAM_BW, buffer)?;
+        self.cmd_with_data(spi, Command::DISPLAY_UPDATE_CONTROL_2, &[0xF7])?;
+        Ok(())
+    }
+
+    fn update_partial_frame(
+        &mut self,
+        _spi: &mut SPI,
+        _buffer: &[u8],
+        _x: u32,
+        _y: u32,
+        _width: u32,
+        _height: u32,
+    ) -> Result<(), SPI::Error> {
+        unimplemented!();
+    }
+
+    fn display_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.command(spi, Command::MASTER_ACTIVATION)?;
+        self.wait_until_idle();
+        Ok(())
+    }
+
+    fn update_and_display_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.update_frame(spi, buffer)?;
+        self.display_frame(spi)?;
+        Ok(())
+    }
+
+    fn clear_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        let pixel_count = WIDTH * HEIGHT / 8;
+        let blank_frame = [0xFF; (WIDTH * HEIGHT / 8) as usize];
+
+        // self.update_and_display_frame(spi, &blank_frame)?;
+
+        self.wait_until_idle();
+        self.cmd_with_data(spi, Command::SET_RAM_Y_AC, &[0x00, 0x00])?;
+
+        for cmd in &[Command::WRITE_RAM_BW, Command::WRITE_RAM_RED] {
+            self.command(spi, *cmd)?;
+            self.interface.data_x_times(spi, 0xFF, pixel_count)?;
+        }
+
+        self.cmd_with_data(spi, Command::DISPLAY_UPDATE_CONTROL_2, &[0xF7])?;
+        self.command(spi, Command::MASTER_ACTIVATION)?;
+        self.wait_until_idle();
+        Ok(())
+    }
+
+    fn set_background_color(&mut self, color: Color) {
+        self.color = color;
+    }
+
+    fn background_color(&self) -> &Color {
+        &self.color
+    }
+
+    fn width(&self) -> u32 {
+        WIDTH
+    }
+
+    fn height(&self) -> u32 {
+        HEIGHT
+    }
+
+    fn set_lut(
+        &mut self,
+        _spi: &mut SPI,
+        _refresh_rate: Option<RefreshLUT>,
+    ) -> Result<(), SPI::Error> {
+        unimplemented!();
+    }
+
+    fn is_busy(&self) -> bool {
+        self.interface.is_busy(IS_BUSY_LOW)
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> EPD7in5<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn command(&mut self, spi: &mut SPI, command: Command) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, command)
+    }
+
+    fn send_data(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
+        self.interface.data(spi, data)
+    }
+
+    fn cmd_with_data(
+        &mut self,
+        spi: &mut SPI,
+        command: Command,
+        data: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd_with_data(spi, command, data)
+    }
+
+    fn wait_until_idle(&mut self) {
+        self.interface.wait_until_idle(IS_BUSY_LOW)
+    }
+
+    // fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+    //     unimplemented!();
+    //     // let w = self.width();
+    //     // let h = self.height();
+
+    //     // self.cmd_with_data(spi, Command::SET_RAM_Y_AC, &[0x00, 0x00])?;
+
+    //     // self.command(spi, Command::TCON_RESOLUTION)?;
+    //     // self.send_data(spi, &[(w >> 8) as u8])?;
+    //     // self.send_data(spi, &[w as u8])?;
+    //     // self.send_data(spi, &[(h >> 8) as u8])?;
+    //     // self.send_data(spi, &[h as u8])
+    // }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epd_size() {
+        assert_eq!(WIDTH, 880);
+        assert_eq!(HEIGHT, 528);
+        assert_eq!(DEFAULT_BACKGROUND_COLOR, Color::Black);
+    }
+}

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -171,9 +171,6 @@ where
 
     fn clear_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
         let pixel_count = WIDTH * HEIGHT / 8;
-        let blank_frame = [0xFF; (WIDTH * HEIGHT / 8) as usize];
-
-        // self.update_and_display_frame(spi, &blank_frame)?;
 
         self.wait_until_idle();
         self.cmd_with_data(spi, Command::SET_RAM_Y_AC, &[0x00, 0x00])?;
@@ -230,10 +227,6 @@ where
         self.interface.cmd(spi, command)
     }
 
-    fn send_data(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
-        self.interface.data(spi, data)
-    }
-
     fn cmd_with_data(
         &mut self,
         spi: &mut SPI,
@@ -246,20 +239,6 @@ where
     fn wait_until_idle(&mut self) {
         self.interface.wait_until_idle(IS_BUSY_LOW)
     }
-
-    // fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
-    //     unimplemented!();
-    //     // let w = self.width();
-    //     // let h = self.height();
-
-    //     // self.cmd_with_data(spi, Command::SET_RAM_Y_AC, &[0x00, 0x00])?;
-
-    //     // self.command(spi, Command::TCON_RESOLUTION)?;
-    //     // self.send_data(spi, &[(w >> 8) as u8])?;
-    //     // self.send_data(spi, &[w as u8])?;
-    //     // self.send_data(spi, &[(h >> 8) as u8])?;
-    //     // self.send_data(spi, &[h as u8])
-    // }
 }
 
 #[cfg(test)]

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -16,7 +16,7 @@ use embedded_hal::{
 
 use crate::color::Color;
 use crate::interface::DisplayInterface;
-use crate::traits::{InternalWiAdditions, RefreshLUT, WaveshareDisplay};
+use crate::traits::{InternalWiAdditions, RefreshLut, WaveshareDisplay};
 
 pub(crate) mod command;
 use self::command::Command;
@@ -211,7 +211,7 @@ where
     fn set_lut(
         &mut self,
         _spi: &mut SPI,
-        _refresh_rate: Option<RefreshLUT>,
+        _refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         unimplemented!();
     }

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -182,7 +182,8 @@ where
 
         for cmd in &[Command::WRITE_RAM_BW, Command::WRITE_RAM_RED] {
             self.command(spi, *cmd)?;
-            self.interface.data_x_times(spi, background_color_byte, pixel_count)?;
+            self.interface
+                .data_x_times(spi, background_color_byte, pixel_count)?;
         }
 
         self.cmd_with_data(spi, Command::DISPLAY_UPDATE_CONTROL_2, &[0xF7])?;

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -16,7 +16,7 @@ pub(crate) struct DisplayInterface<SPI, CS, BUSY, DC, RST> {
     busy: BUSY,
     /// Data/Command Control Pin (High for data, Low for command)
     dc: DC,
-    /// Pin for Reseting
+    /// Pin for Resetting
     rst: RST,
 }
 
@@ -107,7 +107,7 @@ where
             spi.write(data)?;
         }
 
-        // deativate spi with cs high
+        // deactivate spi with cs high
         let _ = self.cs.set_high();
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub mod epd2in9bc;
 pub mod epd4in2;
 pub mod epd5in65f;
 pub mod epd7in5;
+pub mod epd7in5_hd;
 pub mod epd7in5_v2;
 
 pub(crate) mod type_a;


### PR DESCRIPTION
I based this on the `epd7in5_v2` code but uses the hex codes from the 7.5" HD data sheet and ported the procedure from [epd7in5_HD.py](https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd7in5_HD.py).

A difference with this display seems to be that the colours are inverted compared with the other displays (On/0xFF is white) so I've set `DEFAULT_BACKGROUND_COLOR` to `Black`.