### PR TITLE
Added epd2in9_v2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added QuickRefresh Trait and implemented it for EPD4in2 in #62 (thanks to @David-OConnor)
 - Added Epd 2in7 (B) support in #60 (thanks to @pjsier)
 - Added Epd 7in5 HD support
+- Added Epd 2in9 V2 support
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ epd.update_and_display_frame( & mut spi, & display.buffer()) ?;
 | [1.54 Inch B/W (A)](https://www.waveshare.com/1.54inch-e-Paper-Module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 | [2.13 Inch B/W (A) V2](https://www.waveshare.com/product/2.13inch-e-paper-hat.htm) | Black, White | ✕ | ✔ | ✔  | ✔  |
 | [2.9 Inch B/W (A)](https://www.waveshare.com/product/2.9inch-e-paper-module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
+| [2.9 Inch B/W V2 (A)](https://www.waveshare.com/product/2.9inch-e-paper-module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 | [1.54 Inch B/W/R (B)](https://www.waveshare.com/product/modules/oleds-lcds/e-paper/1.54inch-e-paper-module-b.htm) | Black, White, Red | ✕ | ✕ | ✔ | ✔ |
 | [1.54 Inch B/W/Y (C)](https://www.waveshare.com/1.54inch-e-paper-c.htm) | Black, White, Yellow | ✕ | ✕ | ✔ | ✔ |
 | [2.9 Inch B/W/R (B/C)](https://www.waveshare.com/product/displays/e-paper/epaper-2/2.9inch-e-paper-module-b.htm) | Black, White, Red | ✕ | ✕ | ✔ | ✔ |

--- a/src/epd2in9_v2/graphics.rs
+++ b/src/epd2in9_v2/graphics.rs
@@ -1,0 +1,74 @@
+use crate::epd2in9::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
+use crate::graphics::{Display, DisplayRotation};
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::*;
+
+/// Display with Fullsize buffer for use with the 2in9 EPD
+///
+/// Can also be manuall constructed:
+/// `buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); WIDTH / 8 * HEIGHT]`
+pub struct Display2in9 {
+    buffer: [u8; WIDTH as usize * HEIGHT as usize / 8],
+    rotation: DisplayRotation,
+}
+
+impl Default for Display2in9 {
+    fn default() -> Self {
+        Display2in9 {
+            buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value();
+                WIDTH as usize * HEIGHT as usize / 8],
+            rotation: DisplayRotation::default(),
+        }
+    }
+}
+
+impl DrawTarget<BinaryColor> for Display2in9 {
+    type Error = core::convert::Infallible;
+
+    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
+        self.draw_helper(WIDTH, HEIGHT, pixel)
+    }
+
+    fn size(&self) -> Size {
+        Size::new(WIDTH, HEIGHT)
+    }
+}
+
+impl Display for Display2in9 {
+    fn buffer(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    fn get_mut_buffer(&mut self) -> &mut [u8] {
+        &mut self.buffer
+    }
+
+    fn set_rotation(&mut self, rotation: DisplayRotation) {
+        self.rotation = rotation;
+    }
+
+    fn rotation(&self) -> DisplayRotation {
+        self.rotation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // test buffer length
+    #[test]
+    fn graphics_size() {
+        let display = Display2in9::default();
+        assert_eq!(display.buffer().len(), 4736);
+    }
+
+    // test default background color on all bytes
+    #[test]
+    fn graphics_default() {
+        let display = Display2in9::default();
+        for &byte in display.buffer() {
+            assert_eq!(byte, DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+}

--- a/src/epd2in9_v2/graphics.rs
+++ b/src/epd2in9_v2/graphics.rs
@@ -3,7 +3,7 @@ use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
 
-/// Display with Fullsize buffer for use with the 2in9 EPD
+/// Display with Fullsize buffer for use with the 2in9 EPD V2
 ///
 /// Can also be manuall constructed:
 /// `buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); WIDTH / 8 * HEIGHT]`

--- a/src/epd2in9_v2/mod.rs
+++ b/src/epd2in9_v2/mod.rs
@@ -1,5 +1,5 @@
 //! A simple Driver for the Waveshare 2.9" E-Ink Display V2 via SPI
-//! 
+//!
 //! Specification: https://www.waveshare.com/w/upload/7/79/2.9inch-e-paper-v2-specification.pdf
 //!
 //! # Example for the 2.9 in E-Ink Display V2
@@ -51,24 +51,15 @@ pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = false;
 
 const LUT_PARTIAL_2IN9: [u8; 153] = [
-    0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x80,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x40,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0A,0x0,0x0,0x0,0x0,0x0,0x2,  
-    0x1,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x1,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
-    0x22,0x22,0x22,0x22,0x22,0x22,0x0,0x0,0x0,
+    0x0, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80, 0x80, 0x0, 0x0, 0x0, 0x0,
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x40, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+    0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0A, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+    0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x22, 0x22, 0x22, 0x22, 0x22,
+    0x22, 0x0, 0x0, 0x0,
 ];
 
 use embedded_hal::{
@@ -76,9 +67,7 @@ use embedded_hal::{
     digital::v2::*,
 };
 
-use crate::type_a::{
-    command::Command,
-};
+use crate::type_a::command::Command;
 
 use crate::color::Color;
 
@@ -121,24 +110,27 @@ where
         self.wait_until_idle();
         self.interface.cmd(spi, Command::SwReset)?;
         self.wait_until_idle();
-        
+
         // 3 Databytes:
         // A[7:0]
         // 0.. A[8]
         // 0.. B[2:0]
         // Default Values: A = Height of Screen (0x127), B = 0x00 (GD, SM and TB=0?)
-        self.interface.cmd_with_data(spi, Command::DriverOutputControl, &[0x27, 0x01, 0x00])?;
-        
+        self.interface
+            .cmd_with_data(spi, Command::DriverOutputControl, &[0x27, 0x01, 0x00])?;
+
         // One Databyte with default value 0x03
         //  -> address: x increment, y increment, address counter is updated in x direction
-        self.interface.cmd_with_data(spi, Command::DataEntryModeSetting, &[0x03])?;
-        
-        self.set_ram_area(spi, 0, 0, WIDTH-1, HEIGHT-1)?;
-        
-        self.interface.cmd_with_data(spi, Command::DisplayUpdateControl1, &[0x00, 0x80])?;
+        self.interface
+            .cmd_with_data(spi, Command::DataEntryModeSetting, &[0x03])?;
+
+        self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
+
+        self.interface
+            .cmd_with_data(spi, Command::DisplayUpdateControl1, &[0x00, 0x80])?;
 
         self.set_ram_counter(spi, 0, 0)?;
-        
+
         self.wait_until_idle();
         Ok(())
     }
@@ -186,7 +178,8 @@ where
     fn sleep(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
         self.wait_until_idle();
         // 0x00 for Normal mode (Power on Reset), 0x01 for Deep Sleep Mode
-        self.interface.cmd_with_data(spi, Command::DeepSleepMode, &[0x01])?;
+        self.interface
+            .cmd_with_data(spi, Command::DeepSleepMode, &[0x01])?;
         Ok(())
     }
 
@@ -203,7 +196,7 @@ where
         self.wait_until_idle();
         self.interface.cmd_with_data(spi, Command::WriteRam, buffer)
     }
-    
+
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
@@ -225,7 +218,8 @@ where
     fn display_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
         self.wait_until_idle();
         // Enable clock signal, Enable Analog, Load temperature value, DISPLAY with DISPLAY Mode 1, Disable Analog, Disable OSC
-        self.interface.cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xF7])?;
+        self.interface
+            .cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xF7])?;
         self.interface.cmd(spi, Command::MasterActivation)?;
         self.wait_until_idle();
         Ok(())
@@ -342,7 +336,8 @@ where
     /// Set your own LUT, this function is also used internally for set_lut
     fn set_lut_helper(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
         self.wait_until_idle();
-        self.interface.cmd_with_data(spi, Command::WriteLutRegister, buffer)?;
+        self.interface
+            .cmd_with_data(spi, Command::WriteLutRegister, buffer)?;
         self.wait_until_idle();
         Ok(())
     }
@@ -360,29 +355,39 @@ where
     /// To be followed immediately by `update_new_frame`.
     fn update_old_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
         self.wait_until_idle();
-        self.interface.cmd_with_data(spi, Command::WriteRam, buffer)?;
-        self.interface.cmd_with_data(spi, Command::WriteRam2, buffer)
+        self.interface
+            .cmd_with_data(spi, Command::WriteRam, buffer)?;
+        self.interface
+            .cmd_with_data(spi, Command::WriteRam2, buffer)
     }
 
     /// To be used immediately after `update_old_frame`.
     fn update_new_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
         self.wait_until_idle();
         //TODO original waveshare library has a hardware reset for 2 ms. But it works without reset apparently.
-        
+
         self.set_lut_helper(spi, &LUT_PARTIAL_2IN9)?;
-        self.interface.cmd_with_data(spi, Command::WriteOtpSelection, &[0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00])?;
-        self.interface.cmd_with_data(spi, Command::BorderWaveformControl, &[0x80])?;
-        self.interface.cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xC0])?;
+        self.interface.cmd_with_data(
+            spi,
+            Command::WriteOtpSelection,
+            &[0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00],
+        )?;
+        self.interface
+            .cmd_with_data(spi, Command::BorderWaveformControl, &[0x80])?;
+        self.interface
+            .cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xC0])?;
         self.interface.cmd(spi, Command::MasterActivation)?;
-    
+
         self.wait_until_idle();
-    
+
         self.use_full_frame(spi)?;
-    
-        self.interface.cmd_with_data(spi, Command::WriteRam, buffer)?;
+
+        self.interface
+            .cmd_with_data(spi, Command::WriteRam, buffer)?;
         Ok(())
     }
 
+    /// Partial quick refresh not supported yet
     #[allow(unused)]
     fn update_partial_old_frame(
         &mut self,
@@ -396,7 +401,8 @@ where
         //TODO supported by display?
         unimplemented!()
     }
-    
+
+    /// Partial quick refresh not supported yet
     #[allow(unused)]
     fn update_partial_new_frame(
         &mut self,
@@ -410,7 +416,8 @@ where
         //TODO supported by display?
         unimplemented!()
     }
-    
+
+    /// Partial quick refresh not supported yet
     #[allow(unused)]
     fn clear_partial_frame(
         &mut self,

--- a/src/epd2in9_v2/mod.rs
+++ b/src/epd2in9_v2/mod.rs
@@ -1,0 +1,438 @@
+//! A simple Driver for the Waveshare 2.9" E-Ink Display V2 via SPI
+//! 
+//! Specification: https://www.waveshare.com/w/upload/7/79/2.9inch-e-paper-v2-specification.pdf
+//!
+//! # Example for the 2.9 in E-Ink Display V2
+//!
+//!```rust, no_run
+//!# use embedded_hal_mock::*;
+//!# fn main() -> Result<(), MockError> {
+//!use embedded_graphics::{
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+//!};
+//!use epd_waveshare::{epd2in9_v2::*, prelude::*};
+//!#
+//!# let expectations = [];
+//!# let mut spi = spi::Mock::new(&expectations);
+//!# let expectations = [];
+//!# let cs_pin = pin::Mock::new(&expectations);
+//!# let busy_in = pin::Mock::new(&expectations);
+//!# let dc = pin::Mock::new(&expectations);
+//!# let rst = pin::Mock::new(&expectations);
+//!# let mut delay = delay::MockNoop::new();
+//!
+//!// Setup EPD
+//!let mut epd = Epd2in9::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+//!
+//!// Use display graphics from embedded-graphics
+//!let mut display = Display2in9::default();
+//!
+//!// Use embedded graphics for drawing a line
+//!let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
+//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+//!    .draw(&mut display);
+//!
+//!    // Display updated frame
+//!epd.update_frame(&mut spi, &display.buffer())?;
+//!epd.display_frame(&mut spi)?;
+//!
+//!// Set the EPD to sleep
+//!epd.sleep(&mut spi)?;
+//!# Ok(())
+//!# }
+//!```
+
+/// Width of epd2in9 in pixels
+pub const WIDTH: u32 = 128;
+/// Height of epd2in9 in pixels
+pub const HEIGHT: u32 = 296;
+/// Default Background Color (white)
+pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
+const IS_BUSY_LOW: bool = false;
+
+const LUT_PARTIAL_2IN9: [u8; 153] = [
+    0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x80,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x40,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0A,0x0,0x0,0x0,0x0,0x0,0x2,  
+    0x1,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x1,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x0,0x0,0x0,0x0,0x0,0x0,0x0,
+    0x22,0x22,0x22,0x22,0x22,0x22,0x0,0x0,0x0,
+];
+
+use embedded_hal::{
+    blocking::{delay::*, spi::Write},
+    digital::v2::*,
+};
+
+use crate::type_a::{
+    command::Command,
+};
+
+use crate::color::Color;
+
+use crate::traits::*;
+
+use crate::interface::DisplayInterface;
+use crate::traits::QuickRefresh;
+
+#[cfg(feature = "graphics")]
+mod graphics;
+#[cfg(feature = "graphics")]
+pub use crate::epd2in9_v2::graphics::Display2in9;
+
+/// Epd2in9 driver
+///
+pub struct Epd2in9<SPI, CS, BUSY, DC, RST> {
+    /// SPI
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST>,
+    /// Color
+    background_color: Color,
+    /// Refresh LUT
+    refresh: RefreshLut,
+}
+
+impl<SPI, CS, BUSY, DC, RST> Epd2in9<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn init<DELAY: DelayMs<u8>>(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.interface.reset(delay, 2);
+
+        self.wait_until_idle();
+        self.interface.cmd(spi, Command::SwReset)?;
+        self.wait_until_idle();
+        
+        // 3 Databytes:
+        // A[7:0]
+        // 0.. A[8]
+        // 0.. B[2:0]
+        // Default Values: A = Height of Screen (0x127), B = 0x00 (GD, SM and TB=0?)
+        self.interface.cmd_with_data(spi, Command::DriverOutputControl, &[0x27, 0x01, 0x00])?;
+        
+        // One Databyte with default value 0x03
+        //  -> address: x increment, y increment, address counter is updated in x direction
+        self.interface.cmd_with_data(spi, Command::DataEntryModeSetting, &[0x03])?;
+        
+        self.set_ram_area(spi, 0, 0, WIDTH-1, HEIGHT-1)?;
+        
+        self.interface.cmd_with_data(spi, Command::DisplayUpdateControl1, &[0x00, 0x80])?;
+
+        self.set_ram_counter(spi, 0, 0)?;
+        
+        self.wait_until_idle();
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> WaveshareDisplay<SPI, CS, BUSY, DC, RST>
+    for Epd2in9<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    type DisplayColor = Color;
+    fn width(&self) -> u32 {
+        WIDTH
+    }
+
+    fn height(&self) -> u32 {
+        HEIGHT
+    }
+
+    fn new<DELAY: DelayMs<u8>>(
+        spi: &mut SPI,
+        cs: CS,
+        busy: BUSY,
+        dc: DC,
+        rst: RST,
+        delay: &mut DELAY,
+    ) -> Result<Self, SPI::Error> {
+        let interface = DisplayInterface::new(cs, busy, dc, rst);
+
+        let mut epd = Epd2in9 {
+            interface,
+            background_color: DEFAULT_BACKGROUND_COLOR,
+            refresh: RefreshLut::Full,
+        };
+
+        epd.init(spi, delay)?;
+
+        Ok(epd)
+    }
+
+    fn sleep(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        // 0x00 for Normal mode (Power on Reset), 0x01 for Deep Sleep Mode
+        self.interface.cmd_with_data(spi, Command::DeepSleepMode, &[0x01])?;
+        Ok(())
+    }
+
+    fn wake_up<DELAY: DelayMs<u8>>(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.init(spi, delay)?;
+        Ok(())
+    }
+
+    fn update_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.interface.cmd_with_data(spi, Command::WriteRam, buffer)
+    }
+    
+    fn update_partial_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.set_ram_area(spi, x, y, x + width, y + height)?;
+        self.set_ram_counter(spi, x, y)?;
+
+        self.interface
+            .cmd_with_data(spi, Command::WriteRam, buffer)?;
+        Ok(())
+    }
+
+    fn display_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        // Enable clock signal, Enable Analog, Load temperature value, DISPLAY with DISPLAY Mode 1, Disable Analog, Disable OSC
+        self.interface.cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xF7])?;
+        self.interface.cmd(spi, Command::MasterActivation)?;
+        self.wait_until_idle();
+        Ok(())
+    }
+
+    fn update_and_display_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.update_frame(spi, buffer)?;
+        self.display_frame(spi)?;
+        Ok(())
+    }
+
+    fn clear_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+
+        // clear the ram with the background color
+        let color = self.background_color.get_byte_value();
+
+        self.interface.cmd(spi, Command::WriteRam)?;
+        self.interface.data_x_times(spi, color, WIDTH / 8 * HEIGHT)
+    }
+
+    fn set_background_color(&mut self, background_color: Color) {
+        self.background_color = background_color;
+    }
+
+    fn background_color(&self) -> &Color {
+        &self.background_color
+    }
+
+    fn set_lut(
+        &mut self,
+        _spi: &mut SPI,
+        refresh_rate: Option<RefreshLut>,
+    ) -> Result<(), SPI::Error> {
+        if let Some(refresh_lut) = refresh_rate {
+            self.refresh = refresh_lut;
+        }
+        Ok(())
+    }
+
+    fn is_busy(&self) -> bool {
+        self.interface.is_busy(IS_BUSY_LOW)
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> Epd2in9<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    fn wait_until_idle(&mut self) {
+        self.interface.wait_until_idle(IS_BUSY_LOW);
+    }
+
+    fn use_full_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        // choose full frame/ram
+        self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
+
+        // start from the beginning
+        self.set_ram_counter(spi, 0, 0)
+    }
+
+    fn set_ram_area(
+        &mut self,
+        spi: &mut SPI,
+        start_x: u32,
+        start_y: u32,
+        end_x: u32,
+        end_y: u32,
+    ) -> Result<(), SPI::Error> {
+        assert!(start_x < end_x);
+        assert!(start_y < end_y);
+
+        // x is positioned in bytes, so the last 3 bits which show the position inside a byte in the ram
+        // aren't relevant
+        self.interface.cmd_with_data(
+            spi,
+            Command::SetRamXAddressStartEndPosition,
+            &[(start_x >> 3) as u8, (end_x >> 3) as u8],
+        )?;
+
+        // 2 Databytes: A[7:0] & 0..A[8] for each - start and end
+        self.interface.cmd_with_data(
+            spi,
+            Command::SetRamYAddressStartEndPosition,
+            &[
+                start_y as u8,
+                (start_y >> 8) as u8,
+                end_y as u8,
+                (end_y >> 8) as u8,
+            ],
+        )
+    }
+
+    fn set_ram_counter(&mut self, spi: &mut SPI, x: u32, y: u32) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        // x is positioned in bytes, so the last 3 bits which show the position inside a byte in the ram
+        // aren't relevant
+        self.interface
+            .cmd_with_data(spi, Command::SetRamXAddressCounter, &[x as u8])?;
+
+        // 2 Databytes: A[7:0] & 0..A[8]
+        self.interface.cmd_with_data(
+            spi,
+            Command::SetRamYAddressCounter,
+            &[y as u8, (y >> 8) as u8],
+        )?;
+        Ok(())
+    }
+
+    /// Set your own LUT, this function is also used internally for set_lut
+    fn set_lut_helper(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.interface.cmd_with_data(spi, Command::WriteLutRegister, buffer)?;
+        self.wait_until_idle();
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST> QuickRefresh<SPI, CS, BUSY, DC, RST>
+    for Epd2in9<SPI, CS, BUSY, DC, RST>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+{
+    /// To be followed immediately by `update_new_frame`.
+    fn update_old_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        self.interface.cmd_with_data(spi, Command::WriteRam, buffer)?;
+        self.interface.cmd_with_data(spi, Command::WriteRam2, buffer)
+    }
+
+    /// To be used immediately after `update_old_frame`.
+    fn update_new_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+        self.wait_until_idle();
+        //TODO original waveshare library has a hardware reset for 2 ms. But it works without reset apparently.
+        
+        self.set_lut_helper(spi, &LUT_PARTIAL_2IN9)?;
+        self.interface.cmd_with_data(spi, Command::WriteOtpSelection, &[0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00])?;
+        self.interface.cmd_with_data(spi, Command::BorderWaveformControl, &[0x80])?;
+        self.interface.cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xC0])?;
+        self.interface.cmd(spi, Command::MasterActivation)?;
+    
+        self.wait_until_idle();
+    
+        self.use_full_frame(spi)?;
+    
+        self.interface.cmd_with_data(spi, Command::WriteRam, buffer)?;
+        Ok(())
+    }
+
+    #[allow(unused)]
+    fn update_partial_old_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), SPI::Error> {
+        //TODO supported by display?
+        unimplemented!()
+    }
+    
+    #[allow(unused)]
+    fn update_partial_new_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), SPI::Error> {
+        //TODO supported by display?
+        unimplemented!()
+    }
+    
+    #[allow(unused)]
+    fn clear_partial_frame(
+        &mut self,
+        spi: &mut SPI,
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), SPI::Error> {
+        //TODO supported by display?
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epd_size() {
+        assert_eq!(WIDTH, 128);
+        assert_eq!(HEIGHT, 296);
+        assert_eq!(DEFAULT_BACKGROUND_COLOR, Color::White);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod epd1in54c;
 pub mod epd2in13_v2;
 pub mod epd2in7b;
 pub mod epd2in9;
+pub mod epd2in9_v2;
 pub mod epd2in9bc;
 pub mod epd4in2;
 pub mod epd5in65f;

--- a/src/type_a/command.rs
+++ b/src/type_a/command.rs
@@ -49,9 +49,13 @@ pub(crate) enum Command {
 
     WriteRam = 0x24,
 
+    WriteRam2 = 0x26,
+
     WriteVcomRegister = 0x2C,
 
     WriteLutRegister = 0x32,
+    
+    WriteOtpSelection = 0x37,
 
     SetDummyLinePeriod = 0x3A,
 

--- a/src/type_a/command.rs
+++ b/src/type_a/command.rs
@@ -54,7 +54,7 @@ pub(crate) enum Command {
     WriteVcomRegister = 0x2C,
 
     WriteLutRegister = 0x32,
-    
+
     WriteOtpSelection = 0x37,
 
     SetDummyLinePeriod = 0x3A,


### PR DESCRIPTION
I added support for the 2.9 display version 2. It is mostly copy paste from the version 1. I used the libraries provided by waveshare (https://www.waveshare.com/wiki/2.9inch_e-Paper_Module) to implement the changed behavior. Quick refresh is also supported and tested.