### PR TITLE
Fixed epd2in9 quick refresh

### DIFF
--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -439,7 +439,7 @@ where
     }
 }
 
-impl<SPI, CS, BUSY, DC, RST, DELAY> QuickRefresh<SPI, CS, BUSY, DC, RST>
+impl<SPI, CS, BUSY, DC, RST, DELAY> QuickRefresh<SPI, CS, BUSY, DC, RST, DELAY>
     for Epd4in2<SPI, CS, BUSY, DC, RST, DELAY>
 where
     SPI: Write<u8>,
@@ -450,7 +450,12 @@ where
     DELAY: DelayMs<u8>,
 {
     /// To be followed immediately after by `update_old_frame`.
-    fn update_old_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+    fn update_old_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        _delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
         self.wait_until_idle();
 
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
@@ -461,7 +466,12 @@ where
     }
 
     /// To be used immediately after `update_old_frame`.
-    fn update_new_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
+    fn update_new_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        _delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
         self.wait_until_idle();
         // self.send_resolution(spi)?;
 
@@ -470,6 +480,23 @@ where
         self.interface.data(spi, buffer)?;
 
         Ok(())
+    }
+
+    /// This function is not needed for this display
+    #[allow(unused)]
+    fn display_new_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        unimplemented!()
+    }
+
+    /// This function is not needed for this display
+    #[allow(unused)]
+    fn update_and_display_new_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        unimplemented!()
     }
 
     fn update_partial_old_frame(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -280,19 +280,41 @@ where
 ///# Ok(())
 ///# }
 ///```
-pub trait QuickRefresh<SPI, CS, BUSY, DC, RST>
+pub trait QuickRefresh<SPI, CS, BUSY, DC, RST, DELAY>
 where
     SPI: Write<u8>,
     CS: OutputPin,
     BUSY: InputPin,
     DC: OutputPin,
     RST: OutputPin,
+    DELAY: DelayMs<u8>,
 {
     /// Updates the old frame.
-    fn update_old_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error>;
+    fn update_old_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error>;
 
     /// Updates the new frame.
-    fn update_new_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error>;
+    fn update_new_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error>;
+
+    /// Displays the new frame
+    fn display_new_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error>;
+
+    /// Updates and displays the new frame.
+    fn update_and_display_new_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error>;
 
     /// Updates the old frame for a portion of the display.
     fn update_partial_old_frame(


### PR DESCRIPTION
I did some testing with my display and I noticed that the quick refresh does not work properly. There is ghosting. The remedy is to insert a hardware reset and to change the display routine (as in the original library). Now it works very fine.
However, I am not quite happy with the interface changes. I needed the delay parameter for the hardware reset and new function for displaying the new frame which is apparently not needed for the epd4in2 display. But I did not know how to solve this in a better way.
The interface for the quick refresh of the original waveshare library is:

- `void EPD_2IN9_V2_Display_Base(UBYTE *Image)`
  - This function calls `EPD_2IN9_V2_TurnOnDisplay` at the end and equals `update_old_frame` and `display_frame`
- `void EPD_2IN9_V2_Display_Partial(UBYTE *Image)`
  - This function calls `EPD_2IN9_V2_TurnOnDisplay_Partial` (with a display update control byte which is not documented in the specification) at the end and equals `update_new_frame` and `display_new_frame`
  - I do not know why they are calling this "partial". The whole display is updated. The real partial update is apparently not working.

