### PR TITLE
add support for 2in13bc tri-color e-ink display

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ epd.update_and_display_frame( & mut spi, & display.buffer()) ?;
 | [4.2 Inch B/W (A)](https://www.waveshare.com/product/4.2inch-e-paper-module.htm) | Black, White | ✕ | Not officially [[2](#2-42-inch-e-ink-blackwhite---partial-refresh)] | ✔ | ✔ |
 | [1.54 Inch B/W (A)](https://www.waveshare.com/1.54inch-e-Paper-Module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 | [2.13 Inch B/W (A) V2](https://www.waveshare.com/product/2.13inch-e-paper-hat.htm) | Black, White | ✕ | ✔ | ✔  | ✔  |
+| [2.13 Inch B/W/R (B/C) V2](https://www.waveshare.com/product/raspberry-pi/displays/e-paper/2.13inch-e-paper-hat-b.htm) | Black, White, Red | ✕ | ✕ | ✔  | ✔  |
 | [2.9 Inch B/W (A)](https://www.waveshare.com/product/2.9inch-e-paper-module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 | [2.9 Inch B/W V2 (A)](https://www.waveshare.com/product/2.9inch-e-paper-module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 | [1.54 Inch B/W/R (B)](https://www.waveshare.com/product/modules/oleds-lcds/e-paper/1.54inch-e-paper-module-b.htm) | Black, White, Red | ✕ | ✕ | ✔ | ✔ |

--- a/examples/epd2in13bc.rs
+++ b/examples/epd2in13bc.rs
@@ -23,6 +23,17 @@ use linux_embedded_hal::{
 // activate spi, gpio in raspi-config
 // needs to be run with sudo because of some sysfs_gpio permission problems and follow-up timing problems
 // see https://github.com/rust-embedded/rust-sysfs-gpio/issues/5 and follow-up issues
+//
+// This example first setups SPI communication using the pin layout found
+// at https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT_(B). This example uses the layout for the
+// Raspberry Pi Zero (RPI Zero). The Chip Select (CS) was taken from the ep2in9 example since CE0 (GPIO8) did
+// not seem to work on RPI Zero with 2.13" HAT
+//
+// The first frame is filled with four texts at different rotations (black on white)
+// The second frame uses a buffer for black/white and a seperate buffer for chromatic/white (i.e. red or yellow)
+// This example draws a sample clock in black on white and two texts using white on red.
+//
+// after finishing, put the display to sleep
 
 fn main() -> Result<(), std::io::Error> {
     let busy = Pin::new(24); // GPIO 24, board J-18
@@ -104,7 +115,8 @@ fn main() -> Result<(), std::io::Error> {
         .into_styled(PrimitiveStyle::with_stroke(Black, 1))
         .draw(&mut display);
 
-    // draw white on Red background
+    // draw text white on Red background by using the chromatic buffer
+
     let _ = Text::new("It's working-WoB!", Point::new(90, 10))
         .into_styled(text_style!(
             font = Font6x8,

--- a/examples/epd2in13bc.rs
+++ b/examples/epd2in13bc.rs
@@ -1,0 +1,148 @@
+#![deny(warnings)]
+
+use embedded_graphics::{
+    fonts::{Font12x16, Font6x8, Text},
+    prelude::*,
+    primitives::{Circle, Line},
+    style::PrimitiveStyle,
+    text_style,
+};
+use embedded_hal::prelude::*;
+use epd_waveshare::{
+    color::*,
+    epd2in13bc::{Display2in13bc, Epd2in13bc},
+    graphics::{Display, DisplayRotation},
+    prelude::*,
+};
+use linux_embedded_hal::{
+    spidev::{self, SpidevOptions},
+    sysfs_gpio::Direction,
+    Delay, Pin, Spidev,
+};
+
+// activate spi, gpio in raspi-config
+// needs to be run with sudo because of some sysfs_gpio permission problems and follow-up timing problems
+// see https://github.com/rust-embedded/rust-sysfs-gpio/issues/5 and follow-up issues
+
+fn main() -> Result<(), std::io::Error> {
+    let busy = Pin::new(24); // GPIO 24, board J-18
+    busy.export().expect("busy export");
+    while !busy.is_exported() {}
+    busy.set_direction(Direction::In).expect("busy Direction");
+
+    let dc = Pin::new(25); // GPIO 25, board J-22
+    dc.export().expect("dc export");
+    while !dc.is_exported() {}
+    dc.set_direction(Direction::Out).expect("dc Direction");
+    // dc.set_value(1).expect("dc Value set to 1");
+
+    let rst = Pin::new(17); // GPIO 17, board J-11
+    rst.export().expect("rst export");
+    while !rst.is_exported() {}
+    rst.set_direction(Direction::Out).expect("rst Direction");
+    // rst.set_value(1).expect("rst Value set to 1");
+
+    // Configure Digital I/O Pin to be used as Chip Select for SPI
+    let cs = Pin::new(26); // CE0, board J-24, GPIO 8 -> doesn work. use this from 2in19 example which works
+    cs.export().expect("cs export");
+    while !cs.is_exported() { }
+    cs.set_direction(Direction::Out).expect("CS Direction");
+    cs.set_value(1).expect("CS Value set to 1");
+
+    // Configure SPI
+    // Settings are taken from
+    let mut spi = Spidev::open("/dev/spidev0.0").expect("spidev directory");
+    let options = SpidevOptions::new()
+        .bits_per_word(8)
+        .max_speed_hz(10_000_000)
+        .mode(spidev::SpiModeFlags::SPI_MODE_0)
+        .build();
+    spi.configure(&options).expect("spi configuration");
+
+    let mut delay = Delay {};
+
+    let mut epd2in13 =
+        Epd2in13bc::new(&mut spi, cs, busy, dc, rst, &mut delay).expect("eink initalize error");
+
+    println!("Test all the rotations");
+    let mut display = Display2in13bc::default();
+    let mut display_chromatic = Display2in13bc::default();
+
+    display.set_rotation(DisplayRotation::Rotate0);
+    draw_text(&mut display, "Rotation 0!", 5, 50);
+
+    display.set_rotation(DisplayRotation::Rotate90);
+    draw_text(&mut display, "Rotation 90!", 5, 50);
+
+    display.set_rotation(DisplayRotation::Rotate180);
+    draw_text(&mut display, "Rotation 180!", 5, 50);
+
+    display.set_rotation(DisplayRotation::Rotate270);
+    draw_text(&mut display, "Rotation 270!", 5, 50);
+
+    epd2in13.update_and_display_frame(&mut spi, &display.buffer(), &mut delay)
+        .expect("display frame new graphics");
+
+    println!("First frame done. Waiting 5s");
+    delay.delay_ms(5000u16);
+
+    println!("Now test new graphics with default rotation:");
+    display.clear_buffer(Color::White);
+    display_chromatic.clear_buffer(Color::White);
+    // keep both displays on same rotation
+    display_chromatic.set_rotation(DisplayRotation::Rotate270); 
+
+    // draw a analog clock
+    let _ = Circle::new(Point::new(64, 	64), 40)
+        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .draw(&mut display);
+    let _ = Line::new(Point::new(64, 64), Point::new(30, 40))
+        .into_styled(PrimitiveStyle::with_stroke(Black, 4))
+        .draw(&mut display);
+    let _ = Line::new(Point::new(64, 64), Point::new(80, 40))
+        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .draw(&mut display);
+
+    // draw white on Red background
+    let _ = Text::new("It's working-WoB!", Point::new(90, 10))
+        .into_styled(text_style!(
+            font = Font6x8,
+            text_color = White,
+            background_color = Black
+        ))
+        .draw(&mut display_chromatic);
+
+    // use bigger/different font
+    let _ = Text::new("It's working-WoB!", Point::new(90, 40))
+        .into_styled(text_style!(
+            font = Font12x16,
+            text_color = White,
+            background_color = Black
+        ))
+        .draw(&mut display_chromatic);
+
+    epd2in13.update_color_frame(&mut spi, &display.buffer(), &display_chromatic.buffer())?;
+    epd2in13
+        .display_frame(&mut spi, &mut delay)
+        .expect("display frame new graphics");
+    println!("Second frame done. Waiting 5s");
+    delay.delay_ms(5000u16);
+
+    display.clear_buffer(Color::White);
+    display_chromatic.clear_buffer(Color::White);
+    epd2in13.update_color_frame(&mut spi, &display.buffer(), &display_chromatic.buffer())?;
+    epd2in13.display_frame(&mut spi, &mut delay)?;
+
+    println!("Finished tests - going to sleep"); 
+    epd2in13.sleep(&mut spi, &mut delay)
+}
+
+fn draw_text(display: &mut Display2in13bc, text: &str, x: i32, y: i32) {
+    let _ = Text::new(text, Point::new(x, y))
+        .into_styled(text_style!(
+            font = Font6x8,
+            text_color = Black,
+            background_color = White
+        ))
+        .draw(display);
+}

--- a/examples/epd2in13bc.rs
+++ b/examples/epd2in13bc.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), std::io::Error> {
     // Configure Digital I/O Pin to be used as Chip Select for SPI
     let cs = Pin::new(26); // CE0, board J-24, GPIO 8 -> doesn work. use this from 2in19 example which works
     cs.export().expect("cs export");
-    while !cs.is_exported() { }
+    while !cs.is_exported() {}
     cs.set_direction(Direction::Out).expect("CS Direction");
     cs.set_value(1).expect("CS Value set to 1");
 
@@ -80,7 +80,8 @@ fn main() -> Result<(), std::io::Error> {
     display.set_rotation(DisplayRotation::Rotate270);
     draw_text(&mut display, "Rotation 270!", 5, 50);
 
-    epd2in13.update_and_display_frame(&mut spi, &display.buffer(), &mut delay)
+    epd2in13
+        .update_and_display_frame(&mut spi, &display.buffer(), &mut delay)
         .expect("display frame new graphics");
 
     println!("First frame done. Waiting 5s");
@@ -90,10 +91,10 @@ fn main() -> Result<(), std::io::Error> {
     display.clear_buffer(Color::White);
     display_chromatic.clear_buffer(Color::White);
     // keep both displays on same rotation
-    display_chromatic.set_rotation(DisplayRotation::Rotate270); 
+    display_chromatic.set_rotation(DisplayRotation::Rotate270);
 
     // draw a analog clock
-    let _ = Circle::new(Point::new(64, 	64), 40)
+    let _ = Circle::new(Point::new(64, 64), 40)
         .into_styled(PrimitiveStyle::with_stroke(Black, 1))
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(30, 40))
@@ -133,7 +134,7 @@ fn main() -> Result<(), std::io::Error> {
     epd2in13.update_color_frame(&mut spi, &display.buffer(), &display_chromatic.buffer())?;
     epd2in13.display_frame(&mut spi, &mut delay)?;
 
-    println!("Finished tests - going to sleep"); 
+    println!("Finished tests - going to sleep");
     epd2in13.sleep(&mut spi, &mut delay)
 }
 

--- a/src/epd2in13bc/command.rs
+++ b/src/epd2in13bc/command.rs
@@ -1,0 +1,38 @@
+//! SPI Commands for the Waveshare 2.9" (B/C) E-Ink Display
+use crate::traits;
+
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub(crate) enum Command {
+    PanelSetting = 0x00,
+
+    PowerSetting = 0x01,
+    PowerOff = 0x02,
+    PowerOn = 0x04,
+    BoosterSoftStart = 0x06,
+    DeepSleep = 0x07,
+    DataStartTransmission1 = 0x10,
+    DisplayRefresh = 0x12,
+    DataStartTransmission2 = 0x13,
+
+    LutForVcom = 0x20,
+    LutWhiteToWhite = 0x21,
+    LutBlackToWhite = 0x22,
+    LutWhiteToBlack = 0x23,
+    LutBlackToBlack = 0x24,
+
+    PllControl = 0x30,
+    TemperatureSensor = 0x40,
+    TemperatureSensorSelection = 0x41,
+    VcomAndDataIntervalSetting = 0x50,
+    ResolutionSetting = 0x61,
+    VcmDcSetting = 0x82,
+    PowerSaving = 0xE3,
+}
+
+impl traits::Command for Command {
+    /// Returns the address of the command
+    fn address(self) -> u8 {
+        self as u8
+    }
+}

--- a/src/epd2in13bc/command.rs
+++ b/src/epd2in13bc/command.rs
@@ -1,4 +1,4 @@
-//! SPI Commands for the Waveshare 2.9" (B/C) E-Ink Display
+//! SPI Commands for the Waveshare 2.13" (B/C) E-Ink Display
 use crate::traits;
 
 #[allow(dead_code)]

--- a/src/epd2in13bc/graphics.rs
+++ b/src/epd2in13bc/graphics.rs
@@ -1,4 +1,4 @@
-use crate::epd2in9bc::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
+use crate::epd2in13bc::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
@@ -6,21 +6,21 @@ use embedded_graphics::prelude::*;
 /// Full size buffer for use with the 2in9b/c EPD
 ///
 /// Can also be manually constructed and be used together with VarDisplay
-pub struct Display2in9bc {
+pub struct Display2in13bc {
     buffer: [u8; NUM_DISPLAY_BITS as usize],
     rotation: DisplayRotation,
 }
 
-impl Default for Display2in9bc {
+impl Default for Display2in13bc {
     fn default() -> Self {
-        Display2in9bc {
+        Display2in13bc {
             buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); NUM_DISPLAY_BITS as usize],
             rotation: DisplayRotation::default(),
         }
     }
 }
 
-impl DrawTarget<BinaryColor> for Display2in9bc {
+impl DrawTarget<BinaryColor> for Display2in13bc {
     type Error = core::convert::Infallible;
 
     fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
@@ -32,7 +32,7 @@ impl DrawTarget<BinaryColor> for Display2in9bc {
     }
 }
 
-impl Display for Display2in9bc {
+impl Display for Display2in13bc {
     fn buffer(&self) -> &[u8] {
         &self.buffer
     }

--- a/src/epd2in13bc/graphics.rs
+++ b/src/epd2in13bc/graphics.rs
@@ -1,0 +1,51 @@
+use crate::epd2in9bc::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
+use crate::graphics::{Display, DisplayRotation};
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::*;
+
+/// Full size buffer for use with the 2in9b/c EPD
+///
+/// Can also be manually constructed and be used together with VarDisplay
+pub struct Display2in9bc {
+    buffer: [u8; NUM_DISPLAY_BITS as usize],
+    rotation: DisplayRotation,
+}
+
+impl Default for Display2in9bc {
+    fn default() -> Self {
+        Display2in9bc {
+            buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); NUM_DISPLAY_BITS as usize],
+            rotation: DisplayRotation::default(),
+        }
+    }
+}
+
+impl DrawTarget<BinaryColor> for Display2in9bc {
+    type Error = core::convert::Infallible;
+
+    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
+        self.draw_helper(WIDTH, HEIGHT, pixel)
+    }
+
+    fn size(&self) -> Size {
+        Size::new(WIDTH, HEIGHT)
+    }
+}
+
+impl Display for Display2in9bc {
+    fn buffer(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    fn get_mut_buffer(&mut self) -> &mut [u8] {
+        &mut self.buffer
+    }
+
+    fn set_rotation(&mut self, rotation: DisplayRotation) {
+        self.rotation = rotation;
+    }
+
+    fn rotation(&self) -> DisplayRotation {
+        self.rotation
+    }
+}

--- a/src/epd2in13bc/graphics.rs
+++ b/src/epd2in13bc/graphics.rs
@@ -3,7 +3,7 @@ use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
 
-/// Full size buffer for use with the 2in9b/c EPD
+/// Full size buffer for use with the 2in13b/c EPD
 ///
 /// Can also be manually constructed and be used together with VarDisplay
 pub struct Display2in13bc {

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -1,0 +1,389 @@
+//! A simple Driver for the Waveshare 2.9" (B/C) E-Ink Display via SPI
+//!
+//! # Example for the 2.9" E-Ink Display
+//!
+//!```rust, no_run
+//!# use embedded_hal_mock::*;
+//!# fn main() -> Result<(), MockError> {
+//!use embedded_graphics::{
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+//!};
+//!use epd_waveshare::{epd2in9bc::*, prelude::*};
+//!#
+//!# let expectations = [];
+//!# let mut spi = spi::Mock::new(&expectations);
+//!# let expectations = [];
+//!# let cs_pin = pin::Mock::new(&expectations);
+//!# let busy_in = pin::Mock::new(&expectations);
+//!# let dc = pin::Mock::new(&expectations);
+//!# let rst = pin::Mock::new(&expectations);
+//!# let mut delay = delay::MockNoop::new();
+//!
+//!// Setup EPD
+//!let mut epd = Epd2in9bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+//!
+//!// Use display graphics from embedded-graphics
+//!// This display is for the black/white pixels
+//!let mut mono_display = Display2in9bc::default();
+//!
+//!// Use embedded graphics for drawing
+//!// A black line
+//!let _ = Line::new(Point::new(0, 120), Point::new(0, 200))
+//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+//!    .draw(&mut mono_display);
+//!
+//!// Use a second display for red/yellow
+//!let mut chromatic_display = Display2in9bc::default();
+//!
+//!// We use `Black` but it will be shown as red/yellow
+//!let _ = Line::new(Point::new(15, 120), Point::new(15, 200))
+//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+//!    .draw(&mut chromatic_display);
+//!
+//!// Display updated frame
+//!epd.update_color_frame(
+//!    &mut spi,
+//!    &mono_display.buffer(),
+//!    &chromatic_display.buffer()
+//!)?;
+//!epd.display_frame(&mut spi, &mut delay)?;
+//!
+//!// Set the EPD to sleep
+//!epd.sleep(&mut spi, &mut delay)?;
+//!# Ok(())
+//!# }
+//!```
+use embedded_hal::{
+    blocking::{delay::*, spi::Write},
+    digital::v2::*,
+};
+
+use crate::interface::DisplayInterface;
+use crate::traits::{
+    InternalWiAdditions, RefreshLut, WaveshareDisplay, WaveshareThreeColorDisplay,
+};
+
+/// Width of epd2in9bc in pixels
+pub const WIDTH: u32 = 128;
+/// Height of epd2in9bc in pixels
+pub const HEIGHT: u32 = 296;
+/// Default background color (white) of epd2in9bc display
+pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
+
+const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
+
+const IS_BUSY_LOW: bool = true;
+const VCOM_DATA_INTERVAL: u8 = 0x07;
+const WHITE_BORDER: u8 = 0x70;
+const BLACK_BORDER: u8 = 0x30;
+const CHROMATIC_BORDER: u8 = 0xb0;
+const FLOATING_BORDER: u8 = 0xF0;
+
+use crate::color::{Color, TriColor};
+
+pub(crate) mod command;
+use self::command::Command;
+
+#[cfg(feature = "graphics")]
+mod graphics;
+#[cfg(feature = "graphics")]
+pub use self::graphics::Display2in9bc;
+
+/// Epd2in9bc driver
+pub struct Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY> {
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    color: Color,
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> InternalWiAdditions<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayMs<u8>,
+{
+    fn init(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        // Values taken from datasheet and sample code
+
+        self.interface.reset(delay, 10);
+
+        // start the booster
+        self.interface
+            .cmd_with_data(spi, Command::BoosterSoftStart, &[0x17, 0x17, 0x17])?;
+
+        // power on
+        self.command(spi, Command::PowerOn)?;
+        delay.delay_ms(5);
+        self.wait_until_idle();
+
+        // set the panel settings
+        self.cmd_with_data(spi, Command::PanelSetting, &[0x8F])?;
+
+        self.cmd_with_data(
+            spi,
+            Command::VcomAndDataIntervalSetting,
+            &[WHITE_BORDER | VCOM_DATA_INTERVAL],
+        )?;
+
+        // set resolution
+        self.send_resolution(spi)?;
+
+        self.cmd_with_data(spi, Command::VcmDcSetting, &[0x0A])?;
+
+        self.wait_until_idle();
+
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> WaveshareThreeColorDisplay<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayMs<u8>,
+{
+    fn update_color_frame(
+        &mut self,
+        spi: &mut SPI,
+        black: &[u8],
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.update_achromatic_frame(spi, black)?;
+        self.update_chromatic_frame(spi, chromatic)
+    }
+
+    /// Update only the black/white data of the display.
+    ///
+    /// Finish by calling `update_chromatic_frame`.
+    fn update_achromatic_frame(&mut self, spi: &mut SPI, black: &[u8]) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, Command::DataStartTransmission1)?;
+        self.interface.data(spi, black)?;
+        Ok(())
+    }
+
+    /// Update only chromatic data of the display.
+    ///
+    /// This data takes precedence over the black/white data.
+    fn update_chromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, Command::DataStartTransmission2)?;
+        self.interface.data(spi, chromatic)?;
+
+        self.wait_until_idle();
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> WaveshareDisplay<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayMs<u8>,
+{
+    type DisplayColor = Color;
+    fn new(
+        spi: &mut SPI,
+        cs: CS,
+        busy: BUSY,
+        dc: DC,
+        rst: RST,
+        delay: &mut DELAY,
+    ) -> Result<Self, SPI::Error> {
+        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let color = DEFAULT_BACKGROUND_COLOR;
+
+        let mut epd = Epd2in9bc { interface, color };
+
+        epd.init(spi, delay)?;
+
+        Ok(epd)
+    }
+
+    fn sleep(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+        // Section 8.2 from datasheet
+        self.interface.cmd_with_data(
+            spi,
+            Command::VcomAndDataIntervalSetting,
+            &[FLOATING_BORDER | VCOM_DATA_INTERVAL],
+        )?;
+
+        self.command(spi, Command::PowerOff)?;
+        // The example STM code from Github has a wait after PowerOff
+        self.wait_until_idle();
+
+        self.cmd_with_data(spi, Command::DeepSleep, &[0xA5])?;
+
+        Ok(())
+    }
+
+    fn wake_up(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.init(spi, delay)
+    }
+
+    fn set_background_color(&mut self, color: Color) {
+        self.color = color;
+    }
+
+    fn background_color(&self) -> &Color {
+        &self.color
+    }
+
+    fn width(&self) -> u32 {
+        WIDTH
+    }
+
+    fn height(&self) -> u32 {
+        HEIGHT
+    }
+
+    fn update_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        _delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, Command::DataStartTransmission1)?;
+
+        self.interface.data(spi, &buffer)?;
+
+        // Clear the chromatic layer
+        let color = self.color.get_byte_value();
+
+        self.interface.cmd(spi, Command::DataStartTransmission2)?;
+        self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
+
+        self.wait_until_idle();
+        Ok(())
+    }
+
+    #[allow(unused)]
+    fn update_partial_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), SPI::Error> {
+        Ok(())
+    }
+
+    fn display_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.command(spi, Command::DisplayRefresh)?;
+
+        self.wait_until_idle();
+        Ok(())
+    }
+
+    fn update_and_display_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.update_frame(spi, buffer, delay)?;
+        self.display_frame(spi, delay)?;
+        Ok(())
+    }
+
+    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.send_resolution(spi)?;
+
+        let color = DEFAULT_BACKGROUND_COLOR.get_byte_value();
+
+        // Clear the black
+        self.interface.cmd(spi, Command::DataStartTransmission1)?;
+
+        self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
+
+        // Clear the chromatic
+        self.interface.cmd(spi, Command::DataStartTransmission2)?;
+        self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
+
+        self.wait_until_idle();
+        Ok(())
+    }
+
+    fn set_lut(
+        &mut self,
+        _spi: &mut SPI,
+        _refresh_rate: Option<RefreshLut>,
+    ) -> Result<(), SPI::Error> {
+        Ok(())
+    }
+
+    fn is_busy(&self) -> bool {
+        self.interface.is_busy(IS_BUSY_LOW)
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayMs<u8>,
+{
+    fn command(&mut self, spi: &mut SPI, command: Command) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, command)
+    }
+
+    fn send_data(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
+        self.interface.data(spi, data)
+    }
+
+    fn cmd_with_data(
+        &mut self,
+        spi: &mut SPI,
+        command: Command,
+        data: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd_with_data(spi, command, data)
+    }
+
+    fn wait_until_idle(&mut self) {
+        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+    }
+
+    fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        let w = self.width();
+        let h = self.height();
+
+        self.command(spi, Command::ResolutionSetting)?;
+
+        self.send_data(spi, &[w as u8])?;
+        self.send_data(spi, &[(h >> 8) as u8])?;
+        self.send_data(spi, &[h as u8])
+    }
+
+    /// Set the outer border of the display to the chosen color.
+    pub fn set_border_color(&mut self, spi: &mut SPI, color: TriColor) -> Result<(), SPI::Error> {
+        let border = match color {
+            TriColor::Black => BLACK_BORDER,
+            TriColor::White => WHITE_BORDER,
+            TriColor::Chromatic => CHROMATIC_BORDER,
+        };
+        self.cmd_with_data(
+            spi,
+            Command::VcomAndDataIntervalSetting,
+            &[border | VCOM_DATA_INTERVAL],
+        )
+    }
+}

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -1,6 +1,6 @@
-//! A simple Driver for the Waveshare 2.9" (B/C) E-Ink Display via SPI
+//! A simple Driver for the Waveshare 2.13" (B/C) E-Ink Display via SPI
 //!
-//! # Example for the 2.9" E-Ink Display
+//! # Example for the 2.13" E-Ink Display
 //!
 //!```rust, no_run
 //!# use embedded_hal_mock::*;
@@ -8,7 +8,7 @@
 //!use embedded_graphics::{
 //!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
 //!};
-//!use epd_waveshare::{epd2in9bc::*, prelude::*};
+//!use epd_waveshare::{epd2in13bc::*, prelude::*};
 //!#
 //!# let expectations = [];
 //!# let mut spi = spi::Mock::new(&expectations);
@@ -20,11 +20,11 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd2in9bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+//!let mut epd = Epd2in13bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!// This display is for the black/white pixels
-//!let mut mono_display = Display2in9bc::default();
+//!let mut mono_display = Display2in13bc::default();
 //!
 //!// Use embedded graphics for drawing
 //!// A black line
@@ -33,7 +33,7 @@
 //!    .draw(&mut mono_display);
 //!
 //!// Use a second display for red/yellow
-//!let mut chromatic_display = Display2in9bc::default();
+//!let mut chromatic_display = Display2in13bc::default();
 //!
 //!// We use `Black` but it will be shown as red/yellow
 //!let _ = Line::new(Point::new(15, 120), Point::new(15, 200))
@@ -63,9 +63,9 @@ use crate::traits::{
     InternalWiAdditions, RefreshLut, WaveshareDisplay, WaveshareThreeColorDisplay,
 };
 
-/// Width of epd2in9bc in pixels
+/// Width of epd2in13bc in pixels
 pub const WIDTH: u32 = 128;
-/// Height of epd2in9bc in pixels
+/// Height of epd2in13bc in pixels
 pub const HEIGHT: u32 = 296;
 /// Default background color (white) of epd2in9bc display
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
@@ -87,16 +87,16 @@ use self::command::Command;
 #[cfg(feature = "graphics")]
 mod graphics;
 #[cfg(feature = "graphics")]
-pub use self::graphics::Display2in9bc;
+pub use self::graphics::Display2in13bc;
 
 /// Epd2in9bc driver
-pub struct Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY> {
+pub struct Epd2in13bc<SPI, CS, BUSY, DC, RST, DELAY> {
     interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
     color: Color,
 }
 
 impl<SPI, CS, BUSY, DC, RST, DELAY> InternalWiAdditions<SPI, CS, BUSY, DC, RST, DELAY>
-    for Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd2in13bc<SPI, CS, BUSY, DC, RST, DELAY>
 where
     SPI: Write<u8>,
     CS: OutputPin,
@@ -140,7 +140,7 @@ where
 }
 
 impl<SPI, CS, BUSY, DC, RST, DELAY> WaveshareThreeColorDisplay<SPI, CS, BUSY, DC, RST, DELAY>
-    for Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd2in13bc<SPI, CS, BUSY, DC, RST, DELAY>
 where
     SPI: Write<u8>,
     CS: OutputPin,
@@ -185,7 +185,7 @@ where
 }
 
 impl<SPI, CS, BUSY, DC, RST, DELAY> WaveshareDisplay<SPI, CS, BUSY, DC, RST, DELAY>
-    for Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd2in13bc<SPI, CS, BUSY, DC, RST, DELAY>
 where
     SPI: Write<u8>,
     CS: OutputPin,
@@ -206,7 +206,7 @@ where
         let interface = DisplayInterface::new(cs, busy, dc, rst);
         let color = DEFAULT_BACKGROUND_COLOR;
 
-        let mut epd = Epd2in9bc { interface, color };
+        let mut epd = Epd2in13bc { interface, color };
 
         epd.init(spi, delay)?;
 
@@ -332,7 +332,7 @@ where
     }
 }
 
-impl<SPI, CS, BUSY, DC, RST, DELAY> Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY>
+impl<SPI, CS, BUSY, DC, RST, DELAY> Epd2in13bc<SPI, CS, BUSY, DC, RST, DELAY>
 where
     SPI: Write<u8>,
     CS: OutputPin,

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -64,9 +64,9 @@ use crate::traits::{
 };
 
 /// Width of epd2in13bc in pixels
-pub const WIDTH: u32 = 128;
+pub const WIDTH: u32 = 104;
 /// Height of epd2in13bc in pixels
-pub const HEIGHT: u32 = 296;
+pub const HEIGHT: u32 = 212;
 /// Default background color (white) of epd2in9bc display
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -1,4 +1,6 @@
 //! A simple Driver for the Waveshare 2.13" (B/C) E-Ink Display via SPI
+//! More information on this display can be found at the [Waveshare Wiki]:(https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT_(B))
+//! This driver was build and tested for 212x104, 2.13inch E-Ink display HAT for Raspberry Pi, three-color, SPI interface
 //!
 //! # Example for the 2.13" E-Ink Display
 //!
@@ -67,7 +69,7 @@ use crate::traits::{
 pub const WIDTH: u32 = 104;
 /// Height of epd2in13bc in pixels
 pub const HEIGHT: u32 = 212;
-/// Default background color (white) of epd2in9bc display
+/// Default background color (white) of epd2in13bc display
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 
 const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub mod epd1in54;
 pub mod epd1in54b;
 pub mod epd1in54c;
 pub mod epd2in13_v2;
+pub mod epd2in13bc;
 pub mod epd2in7b;
 pub mod epd2in9;
 pub mod epd2in9_v2;


### PR DESCRIPTION
This PR adds support for Waveshare 2"13 tri-color (b/c) e-ink display. The datasheet is the same as for 2"9 b/c version. Added an example which uses the three colors