### PR TITLE
Enable drawing in three colors for epd2in13

### DIFF
--- a/examples/epd2in13bc.rs
+++ b/examples/epd2in13bc.rs
@@ -91,7 +91,7 @@ fn main() -> Result<(), std::io::Error> {
     display.set_rotation(DisplayRotation::Rotate270);
     draw_text(&mut display, "Rotation 270!", 5, 50);
 
-    // Since we only used black and white, we can resort to updating only 
+    // Since we only used black and white, we can resort to updating only
     // the bw-buffer of this tri-color screen
 
     epd2in13

--- a/src/color.rs
+++ b/src/color.rs
@@ -169,6 +169,28 @@ impl From<u8> for Color {
     }
 }
 
+impl TriColor {
+    /// Get the color encoding of the color for one bit
+    pub fn get_bit_value(self) -> u8 {
+        match self {
+            TriColor::White => 1u8,
+            TriColor::Black | TriColor::Chromatic => 0u8,
+        }
+    }
+
+    /// Gets a full byte of black or white pixels
+    pub fn get_byte_value(self) -> u8 {
+        match self {
+            TriColor::White => 0xff,
+            TriColor::Black | TriColor::Chromatic => 0x00,
+        }
+    }
+}
+
+impl PixelColor for TriColor {
+    type Raw = ();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/color.rs
+++ b/src/color.rs
@@ -187,6 +187,7 @@ impl TriColor {
     }
 }
 
+#[cfg(feature = "graphics")]
 impl PixelColor for TriColor {
     type Raw = ();
 }

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -70,8 +70,9 @@ pub const WIDTH: u32 = 104;
 /// Height of epd2in13bc in pixels
 pub const HEIGHT: u32 = 212;
 /// Default background color (white) of epd2in13bc display
-pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
+pub const DEFAULT_BACKGROUND_COLOR: TriColor = TriColor::White;
 
+/// Number of bits for b/w buffer and same for chromatic buffer
 const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
 
 const IS_BUSY_LOW: bool = true;
@@ -81,7 +82,7 @@ const BLACK_BORDER: u8 = 0x30;
 const CHROMATIC_BORDER: u8 = 0xb0;
 const FLOATING_BORDER: u8 = 0xF0;
 
-use crate::color::{Color, TriColor};
+use crate::color::TriColor;
 
 pub(crate) mod command;
 use self::command::Command;
@@ -91,10 +92,10 @@ mod graphics;
 #[cfg(feature = "graphics")]
 pub use self::graphics::Display2in13bc;
 
-/// Epd2in9bc driver
+/// Epd2in13bc driver
 pub struct Epd2in13bc<SPI, CS, BUSY, DC, RST, DELAY> {
     interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
-    color: Color,
+    color: TriColor,
 }
 
 impl<SPI, CS, BUSY, DC, RST, DELAY> InternalWiAdditions<SPI, CS, BUSY, DC, RST, DELAY>
@@ -196,7 +197,7 @@ where
     RST: OutputPin,
     DELAY: DelayMs<u8>,
 {
-    type DisplayColor = Color;
+    type DisplayColor = TriColor;
     fn new(
         spi: &mut SPI,
         cs: CS,
@@ -236,11 +237,11 @@ where
         self.init(spi, delay)
     }
 
-    fn set_background_color(&mut self, color: Color) {
+    fn set_background_color(&mut self, color: TriColor) {
         self.color = color;
     }
 
-    fn background_color(&self) -> &Color {
+    fn background_color(&self) -> &TriColor {
         &self.color
     }
 

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -7,10 +7,8 @@
 //!```rust, no_run
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
-//!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
-//!};
-//!use epd_waveshare::{epd2in13bc::*, prelude::*};
+//!use embedded_graphics::{prelude::*, primitives::Line, style::PrimitiveStyle};
+//!use epd_waveshare::{epd2in13bc::*, prelude::*, color::TriColor};
 //!#
 //!# let expectations = [];
 //!# let mut spi = spi::Mock::new(&expectations);
@@ -25,28 +23,24 @@
 //!let mut epd = Epd2in13bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
 //!
 //!// Use display graphics from embedded-graphics
-//!// This display is for the black/white pixels
-//!let mut mono_display = Display2in13bc::default();
+//!// This display is for the black/white/chromatic pixels
+//!let mut tricolor_display = Display2in13bc::default();
 //!
-//!// Use embedded graphics for drawing
-//!// A black line
+//!// Use embedded graphics for drawing a black line
 //!let _ = Line::new(Point::new(0, 120), Point::new(0, 200))
-//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
-//!    .draw(&mut mono_display);
+//!    .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 1))
+//!    .draw(&mut tricolor_display);
 //!
-//!// Use a second display for red/yellow
-//!let mut chromatic_display = Display2in13bc::default();
-//!
-//!// We use `Black` but it will be shown as red/yellow
+//!// We use `chromatic` but it will be shown as red/yellow
 //!let _ = Line::new(Point::new(15, 120), Point::new(15, 200))
-//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
-//!    .draw(&mut chromatic_display);
+//!    .into_styled(PrimitiveStyle::with_stroke(TriColor::Chromatic, 1))
+//!    .draw(&mut tricolor_display);
 //!
 //!// Display updated frame
 //!epd.update_color_frame(
 //!    &mut spi,
-//!    &mono_display.buffer(),
-//!    &chromatic_display.buffer()
+//!    &tricolor_display.bw_buffer(),
+//!    &tricolor_display.chromatic_buffer()
 //!)?;
 //!epd.display_frame(&mut spi, &mut delay)?;
 //!

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -116,7 +116,7 @@ pub trait TriDisplay: DrawTarget<TriColor> {
 
     /// return the b/w part of the buffer
     fn bw_buffer(&self) -> &[u8];
-    
+
     /// return the chromatic part of the buffer
     fn chromatic_buffer(&self) -> &[u8];
 
@@ -130,12 +130,12 @@ pub trait TriDisplay: DrawTarget<TriColor> {
         pixel: Pixel<TriColor>,
     ) -> Result<(), Self::Error> {
         let rotation = self.rotation();
-        
+
         let Pixel(point, color) = pixel;
         if outside_display(point, width, height, rotation) {
             return Ok(());
         }
-        
+
         // Give us index inside the buffer and the bit-position in that u8 which needs to be changed
         let (index, bit) = find_position(point.x as u32, point.y as u32, width, height, rotation);
         let index = index as usize;
@@ -149,19 +149,19 @@ pub trait TriDisplay: DrawTarget<TriColor> {
                 // clear bit in bw-buffer -> black
                 buffer[index] &= !bit;
                 // set bit in chromatic-buffer -> white
-                buffer[index+offset] |= bit;
+                buffer[index + offset] |= bit;
             }
             TriColor::White => {
                 // set bit in bw-buffer -> white
                 buffer[index] |= bit;
                 // set bit in chromatic-buffer -> white
-                buffer[index+offset] |= bit;
+                buffer[index + offset] |= bit;
             }
             TriColor::Chromatic => {
                 // set bit in b/w buffer (white)
                 buffer[index] |= bit;
                 // clear bit in chromatic buffer -> chromatic
-                buffer[index+offset] &= !bit;
+                buffer[index + offset] &= !bit;
             }
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub mod prelude {
     pub use crate::SPI_MODE;
 
     #[cfg(feature = "graphics")]
-    pub use crate::graphics::{Display, DisplayRotation, OctDisplay};
+    pub use crate::graphics::{Display, TriDisplay, DisplayRotation, OctDisplay};
 }
 
 /// Computes the needed buffer length. Takes care of rounding up in case width

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ pub mod prelude {
     pub use crate::SPI_MODE;
 
     #[cfg(feature = "graphics")]
-    pub use crate::graphics::{Display, TriDisplay, DisplayRotation, OctDisplay};
+    pub use crate::graphics::{Display, DisplayRotation, OctDisplay, TriDisplay};
 }
 
 /// Computes the needed buffer length. Takes care of rounding up in case width


### PR DESCRIPTION
Move from BinaryColor to TriColor:  use one Display for drawing

* I use one buffer containing data for b/w and chromatic
* added two fn's to get slice for b/w buffer and slice for chromatic buffer for updating both buffers on the display
* you can still use just the b/w buffer if you want to use two colors
* updated the example to draw b/w and draw using three colors