### PR TITLE
migrate to embedded-graphics 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 # travis-ci = { repository = "caemor/epd-waveshare" }
 
 [dependencies]
-embedded-graphics = { version = "0.7.0", optional = true}
+embedded-graphics = { version = "0.7.1", optional = true}
 embedded-graphics-core = { version = "0.3.2", optional = true}
 embedded-hal = {version = "0.2.4", features = ["unproven"]}
 bit_field = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ edition = "2018"
 # travis-ci = { repository = "caemor/epd-waveshare" }
 
 [dependencies]
-embedded-graphics = { version = "0.6.2", optional = true}
+embedded-graphics = { version = "0.7.0", optional = true}
+embedded-graphics-core = { version = "0.3.2", optional = true}
 embedded-hal = {version = "0.2.4", features = ["unproven"]}
 bit_field = "0.10.1"
 
@@ -27,7 +28,7 @@ embedded-hal-mock = "0.7"
 [features]
 default = ["graphics"]
 
-graphics = ["embedded-graphics"]
+graphics = ["embedded-graphics","embedded-graphics-core"]
 
 # Offers an alternative fast full lut for type_a displays, but the refreshed screen isnt as clean looking
 type_a_alternative_faster_lut = []

--- a/examples/epd2in13_v2.rs
+++ b/examples/epd2in13_v2.rs
@@ -1,17 +1,16 @@
 #![deny(warnings)]
 
 use embedded_graphics::{
-    fonts::{Font12x16, Font6x8, Text},
+    mono_font::MonoTextStyleBuilder,
     prelude::*,
-    primitives::{Circle, Line},
-    style::PrimitiveStyle,
-    text_style,
+    primitives::{Circle, Line, PrimitiveStyleBuilder},
+    text::{Baseline, Text, TextStyleBuilder},
 };
 use embedded_hal::prelude::*;
 use epd_waveshare::{
     color::*,
     epd2in13_v2::{Display2in13, Epd2in13},
-    graphics::{Display, DisplayRotation},
+    graphics::DisplayRotation,
     prelude::*,
 };
 use linux_embedded_hal::{
@@ -90,32 +89,40 @@ fn main() -> Result<(), std::io::Error> {
     display.clear_buffer(Color::White);
 
     // draw a analog clock
+    let style = PrimitiveStyleBuilder::new()
+        .stroke_color(Black)
+        .stroke_width(1)
+        .build();
+
     let _ = Circle::new(Point::new(64, 64), 40)
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .into_styled(style)
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(30, 40))
-        .into_styled(PrimitiveStyle::with_stroke(Black, 4))
+        .into_styled(style)
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(80, 40))
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .into_styled(style)
         .draw(&mut display);
 
     // draw white on black background
-    let _ = Text::new("It's working-WoB!", Point::new(90, 10))
-        .into_styled(text_style!(
-            font = Font6x8,
-            text_color = White,
-            background_color = Black
-        ))
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_6X10)
+        .text_color(White)
+        .background_color(Black)
+        .build();
+    let text_style = TextStyleBuilder::new().baseline(Baseline::Top).build();
+
+    let _ = Text::with_text_style("It's working-WoB!", Point::new(90, 10), style, text_style)
         .draw(&mut display);
 
     // use bigger/different font
-    let _ = Text::new("It's working-WoB!", Point::new(90, 40))
-        .into_styled(text_style!(
-            font = Font12x16,
-            text_color = White,
-            background_color = Black
-        ))
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_10X20)
+        .text_color(White)
+        .background_color(Black)
+        .build();
+
+    let _ = Text::with_text_style("It's working-WoB!", Point::new(90, 40), style, text_style)
         .draw(&mut display);
 
     // Demonstrating how to use the partial refresh feature of the screen.
@@ -157,11 +164,13 @@ fn main() -> Result<(), std::io::Error> {
 }
 
 fn draw_text(display: &mut Display2in13, text: &str, x: i32, y: i32) {
-    let _ = Text::new(text, Point::new(x, y))
-        .into_styled(text_style!(
-            font = Font6x8,
-            text_color = Black,
-            background_color = White
-        ))
-        .draw(display);
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_6X10)
+        .text_color(White)
+        .background_color(Black)
+        .build();
+
+    let text_style = TextStyleBuilder::new().baseline(Baseline::Top).build();
+
+    let _ = Text::with_text_style(text, Point::new(x, y), style, text_style).draw(display);
 }

--- a/examples/epd2in13_v2.rs
+++ b/examples/epd2in13_v2.rs
@@ -89,7 +89,7 @@ fn main() -> Result<(), std::io::Error> {
     display.clear_buffer(Color::White);
 
     // draw a analog clock
-    let _ = Circle::new(Point::new(64, 64), 40)
+    let _ = Circle::with_center(Point::new(64, 64), 80)
         .into_styled(PrimitiveStyle::with_stroke(Black, 1))
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(30, 40))
@@ -117,7 +117,7 @@ fn main() -> Result<(), std::io::Error> {
         .background_color(Black)
         .build();
 
-    let _ = Text::with_text_style("It's working-WoB!", Point::new(90, 40), style, text_style)
+    let _ = Text::with_text_style("It's working\nWoB!", Point::new(90, 40), style, text_style)
         .draw(&mut display);
 
     // Demonstrating how to use the partial refresh feature of the screen.

--- a/examples/epd2in13_v2.rs
+++ b/examples/epd2in13_v2.rs
@@ -3,7 +3,7 @@
 use embedded_graphics::{
     mono_font::MonoTextStyleBuilder,
     prelude::*,
-    primitives::{Circle, Line, PrimitiveStyleBuilder},
+    primitives::{Circle, Line, PrimitiveStyle},
     text::{Baseline, Text, TextStyleBuilder},
 };
 use embedded_hal::prelude::*;
@@ -89,19 +89,14 @@ fn main() -> Result<(), std::io::Error> {
     display.clear_buffer(Color::White);
 
     // draw a analog clock
-    let style = PrimitiveStyleBuilder::new()
-        .stroke_color(Black)
-        .stroke_width(1)
-        .build();
-
     let _ = Circle::new(Point::new(64, 64), 40)
-        .into_styled(style)
+        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(30, 40))
-        .into_styled(style)
+        .into_styled(PrimitiveStyle::with_stroke(Black, 4))
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(80, 40))
-        .into_styled(style)
+        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
         .draw(&mut display);
 
     // draw white on black background

--- a/examples/epd2in13bc.rs
+++ b/examples/epd2in13bc.rs
@@ -104,7 +104,7 @@ fn main() -> Result<(), std::io::Error> {
     display.clear_buffer(TriColor::White);
 
     // draw a analog clock
-    let _ = Circle::new(Point::new(64, 64), 40)
+    let _ = Circle::with_center(Point::new(64, 64), 80)
         .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 1))
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(30, 40))
@@ -132,7 +132,7 @@ fn main() -> Result<(), std::io::Error> {
         .background_color(TriColor::Chromatic)
         .build();
 
-    let _ = Text::with_text_style("It's working-WoB!", Point::new(90, 40), style, text_style)
+    let _ = Text::with_text_style("It's working\nWoB!", Point::new(90, 40), style, text_style)
         .draw(&mut display);
 
     // we used three colors, so we need to update both bw-buffer and chromatic-buffer

--- a/examples/epd2in13bc.rs
+++ b/examples/epd2in13bc.rs
@@ -3,7 +3,7 @@
 use embedded_graphics::{
     mono_font::MonoTextStyleBuilder,
     prelude::*,
-    primitives::{Circle, Line, PrimitiveStyleBuilder},
+    primitives::{Circle, Line, PrimitiveStyle},
     text::{Baseline, Text, TextStyleBuilder},
 };
 use embedded_hal::prelude::*;
@@ -104,19 +104,14 @@ fn main() -> Result<(), std::io::Error> {
     display.clear_buffer(TriColor::White);
 
     // draw a analog clock
-    let style = PrimitiveStyleBuilder::new()
-        .stroke_color(TriColor::Black)
-        .stroke_width(1)
-        .build();
-
     let _ = Circle::new(Point::new(64, 64), 40)
-        .into_styled(style)
+        .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 1))
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(30, 40))
-        .into_styled(style)
+        .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 4))
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(80, 40))
-        .into_styled(style)
+        .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 1))
         .draw(&mut display);
 
     // draw text white on Red background by using the chromatic buffer

--- a/examples/epd2in13bc.rs
+++ b/examples/epd2in13bc.rs
@@ -1,11 +1,10 @@
 #![deny(warnings)]
 
 use embedded_graphics::{
-    fonts::{Font12x16, Font6x8, Text},
+    mono_font::MonoTextStyleBuilder,
     prelude::*,
-    primitives::{Circle, Line},
-    style::PrimitiveStyle,
-    text_style,
+    primitives::{Circle, Line, PrimitiveStyleBuilder},
+    text::{Baseline, Text, TextStyleBuilder},
 };
 use embedded_hal::prelude::*;
 use epd_waveshare::{
@@ -104,34 +103,41 @@ fn main() -> Result<(), std::io::Error> {
     println!("Now test new graphics with default rotation and three colors:");
     display.clear_buffer(TriColor::White);
 
-    // draw a analog clock in black
+    // draw a analog clock
+    let style = PrimitiveStyleBuilder::new()
+        .stroke_color(TriColor::Black)
+        .stroke_width(1)
+        .build();
+
     let _ = Circle::new(Point::new(64, 64), 40)
-        .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 1))
+        .into_styled(style)
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(30, 40))
-        .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 4))
+        .into_styled(style)
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(80, 40))
-        .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 1))
+        .into_styled(style)
         .draw(&mut display);
 
-    // draw text white on chromatic (red or yellow) background
+    // draw text white on Red background by using the chromatic buffer
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_6X10)
+        .text_color(TriColor::White)
+        .background_color(TriColor::Chromatic)
+        .build();
+    let text_style = TextStyleBuilder::new().baseline(Baseline::Top).build();
 
-    let _ = Text::new("It's working-WoB!", Point::new(90, 10))
-        .into_styled(text_style!(
-            font = Font6x8,
-            text_color = TriColor::White,
-            background_color = TriColor::Chromatic
-        ))
+    let _ = Text::with_text_style("It's working-WoB!", Point::new(90, 10), style, text_style)
         .draw(&mut display);
 
     // use bigger/different font
-    let _ = Text::new("It's working-WoB!", Point::new(90, 40))
-        .into_styled(text_style!(
-            font = Font12x16,
-            text_color = TriColor::White,
-            background_color = TriColor::Chromatic
-        ))
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_10X20)
+        .text_color(TriColor::White)
+        .background_color(TriColor::Chromatic)
+        .build();
+
+    let _ = Text::with_text_style("It's working-WoB!", Point::new(90, 40), style, text_style)
         .draw(&mut display);
 
     // we used three colors, so we need to update both bw-buffer and chromatic-buffer
@@ -154,11 +160,13 @@ fn main() -> Result<(), std::io::Error> {
 }
 
 fn draw_text(display: &mut Display2in13bc, text: &str, x: i32, y: i32) {
-    let _ = Text::new(text, Point::new(x, y))
-        .into_styled(text_style!(
-            font = Font6x8,
-            text_color = TriColor::Black,
-            background_color = TriColor::White
-        ))
-        .draw(display);
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_6X10)
+        .text_color(TriColor::White)
+        .background_color(TriColor::Black)
+        .build();
+
+    let text_style = TextStyleBuilder::new().baseline(Baseline::Top).build();
+
+    let _ = Text::with_text_style(text, Point::new(x, y), style, text_style).draw(display);
 }

--- a/examples/epd4in2.rs
+++ b/examples/epd4in2.rs
@@ -64,7 +64,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut epd4in2 =
         Epd4in2::new(&mut spi, cs, busy, dc, rst, &mut delay).expect("eink initalize error");
 
-    //println!("Test all the rotations");
+    println!("Test all the rotations");
     let mut display = Display4in2::default();
 
     display.set_rotation(DisplayRotation::Rotate0);
@@ -85,7 +85,7 @@ fn main() -> Result<(), std::io::Error> {
         .expect("display frame new graphics");
     delay.delay_ms(5000u16);
 
-    //println!("Now test new graphics with default rotation and some special stuff:");
+    println!("Now test new graphics with default rotation and some special stuff");
     display.clear_buffer(Color::White);
 
     // draw a analog clock
@@ -94,7 +94,7 @@ fn main() -> Result<(), std::io::Error> {
         .stroke_width(1)
         .build();
 
-    let _ = Circle::new(Point::new(64, 64), 40)
+    let _ = Circle::with_center(Point::new(64, 64), 80)
         .into_styled(style)
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(0, 64))

--- a/examples/epd4in2.rs
+++ b/examples/epd4in2.rs
@@ -1,17 +1,16 @@
 #![deny(warnings)]
 
 use embedded_graphics::{
-    fonts::{Font12x16, Font6x8, Text},
+    mono_font::MonoTextStyleBuilder,
     prelude::*,
-    primitives::{Circle, Line},
-    style::PrimitiveStyle,
-    text_style,
+    primitives::{Circle, Line, PrimitiveStyleBuilder},
+    text::{Baseline, Text, TextStyleBuilder},
 };
 use embedded_hal::prelude::*;
 use epd_waveshare::{
     color::*,
     epd4in2::{Display4in2, Epd4in2},
-    graphics::{Display, DisplayRotation},
+    graphics::DisplayRotation,
     prelude::*,
 };
 use linux_embedded_hal::{
@@ -90,32 +89,40 @@ fn main() -> Result<(), std::io::Error> {
     display.clear_buffer(Color::White);
 
     // draw a analog clock
-    let _ = Circle::new(Point::new(64, 64), 64)
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+    let style = PrimitiveStyleBuilder::new()
+        .stroke_color(Black)
+        .stroke_width(1)
+        .build();
+
+    let _ = Circle::new(Point::new(64, 64), 40)
+        .into_styled(style)
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(0, 64))
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .into_styled(style)
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(80, 80))
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .into_styled(style)
         .draw(&mut display);
 
     // draw white on black background
-    let _ = Text::new("It's working-WoB!", Point::new(175, 250))
-        .into_styled(text_style!(
-            font = Font6x8,
-            text_color = White,
-            background_color = Black
-        ))
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_6X10)
+        .text_color(White)
+        .background_color(Black)
+        .build();
+    let text_style = TextStyleBuilder::new().baseline(Baseline::Top).build();
+
+    let _ = Text::with_text_style("It's working-WoB!", Point::new(175, 250), style, text_style)
         .draw(&mut display);
 
     // use bigger/different font
-    let _ = Text::new("It's working-WoB!", Point::new(50, 200))
-        .into_styled(text_style!(
-            font = Font12x16,
-            text_color = White,
-            background_color = Black
-        ))
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_10X20)
+        .text_color(White)
+        .background_color(Black)
+        .build();
+
+    let _ = Text::with_text_style("It's working-WoB!", Point::new(50, 200), style, text_style)
         .draw(&mut display);
 
     // a moving `Hello World!`
@@ -142,11 +149,13 @@ fn main() -> Result<(), std::io::Error> {
 }
 
 fn draw_text(display: &mut Display4in2, text: &str, x: i32, y: i32) {
-    let _ = Text::new(text, Point::new(x, y))
-        .into_styled(text_style!(
-            font = Font6x8,
-            text_color = Black,
-            background_color = White
-        ))
-        .draw(display);
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_6X10)
+        .text_color(White)
+        .background_color(Black)
+        .build();
+
+    let text_style = TextStyleBuilder::new().baseline(Baseline::Top).build();
+
+    let _ = Text::with_text_style(text, Point::new(x, y), style, text_style).draw(display);
 }

--- a/examples/epd4in2_variable_size.rs
+++ b/examples/epd4in2_variable_size.rs
@@ -2,11 +2,10 @@
 #![deny(warnings)]
 
 use embedded_graphics::{
-    fonts::{Font12x16, Font6x8, Text},
+    mono_font::MonoTextStyleBuilder,
     prelude::*,
-    primitives::{Circle, Line},
-    style::PrimitiveStyle,
-    text_style,
+    primitives::{Circle, Line, PrimitiveStyleBuilder},
+    text::{Baseline, Text, TextStyleBuilder},
 };
 use embedded_hal::prelude::*;
 use epd_waveshare::{
@@ -97,33 +96,40 @@ fn main() -> Result<(), std::io::Error> {
     display.clear_buffer(Color::White);
 
     // draw a analog clock
-    // draw a analog clock
+    let style = PrimitiveStyleBuilder::new()
+        .stroke_color(Black)
+        .stroke_width(1)
+        .build();
+
     let _ = Circle::new(Point::new(64, 64), 64)
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .into_styled(style)
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(0, 64))
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .into_styled(style)
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(80, 80))
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .into_styled(style)
         .draw(&mut display);
 
     // draw white on black background
-    let _ = Text::new("It's working-WoB!", Point::new(175, 250))
-        .into_styled(text_style!(
-            font = Font6x8,
-            text_color = White,
-            background_color = Black
-        ))
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_6X10)
+        .text_color(White)
+        .background_color(Black)
+        .build();
+    let text_style = TextStyleBuilder::new().baseline(Baseline::Top).build();
+
+    let _ = Text::with_text_style("It's working-WoB!", Point::new(175, 250), style, text_style)
         .draw(&mut display);
 
     // use bigger/different font
-    let _ = Text::new("It's working-WoB!", Point::new(50, 200))
-        .into_styled(text_style!(
-            font = Font12x16,
-            text_color = White,
-            background_color = Black
-        ))
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_10X20)
+        .text_color(White)
+        .background_color(Black)
+        .build();
+
+    let _ = Text::with_text_style("It's working-WoB!", Point::new(50, 200), style, text_style)
         .draw(&mut display);
 
     // a moving `Hello World!`
@@ -148,11 +154,13 @@ fn main() -> Result<(), std::io::Error> {
 }
 
 fn draw_text(display: &mut VarDisplay, text: &str, x: i32, y: i32) {
-    let _ = Text::new(text, Point::new(x, y))
-        .into_styled(text_style!(
-            font = Font6x8,
-            text_color = Black,
-            background_color = White
-        ))
-        .draw(display);
+    let style = MonoTextStyleBuilder::new()
+        .font(&embedded_graphics::mono_font::ascii::FONT_6X10)
+        .text_color(White)
+        .background_color(Black)
+        .build();
+
+    let text_style = TextStyleBuilder::new().baseline(Baseline::Top).build();
+
+    let _ = Text::with_text_style(text, Point::new(x, y), style, text_style).draw(display);
 }

--- a/examples/epd4in2_variable_size.rs
+++ b/examples/epd4in2_variable_size.rs
@@ -101,7 +101,7 @@ fn main() -> Result<(), std::io::Error> {
         .stroke_width(1)
         .build();
 
-    let _ = Circle::new(Point::new(64, 64), 64)
+    let _ = Circle::with_center(Point::new(64, 64), 128)
         .into_styled(style)
         .draw(&mut display);
     let _ = Line::new(Point::new(64, 64), Point::new(0, 64))

--- a/src/epd1in54/graphics.rs
+++ b/src/epd1in54/graphics.rs
@@ -25,6 +25,7 @@ impl Default for Display1in54 {
 impl DrawTarget for Display1in54 {
     type Color = BinaryColor;
     type Error = core::convert::Infallible;
+
     fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
     where
         I: IntoIterator<Item = Pixel<Self::Color>>,

--- a/src/epd1in54/graphics.rs
+++ b/src/epd1in54/graphics.rs
@@ -1,7 +1,7 @@
 use crate::epd1in54::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
-use embedded_graphics::prelude::*;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 1in54 EPD
 ///
@@ -22,13 +22,21 @@ impl Default for Display1in54 {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display1in54 {
+impl DrawTarget for Display1in54 {
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
-
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display1in54 {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }
@@ -57,7 +65,10 @@ mod tests {
     use super::*;
     use crate::color::{Black, Color};
     use crate::graphics::{Display, DisplayRotation};
-    use embedded_graphics::{primitives::Line, style::PrimitiveStyle};
+    use embedded_graphics::{
+        prelude::*,
+        primitives::{Line, PrimitiveStyleBuilder},
+    };
 
     // test buffer length
     #[test]
@@ -79,7 +90,12 @@ mod tests {
     fn graphics_rotation_0() {
         let mut display = Display1in54::default();
         let _ = Line::new(Point::new(0, 0), Point::new(7, 0))
-            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Black)
+                    .stroke_width(1)
+                    .build(),
+            )
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -96,7 +112,12 @@ mod tests {
         let mut display = Display1in54::default();
         display.set_rotation(DisplayRotation::Rotate90);
         let _ = Line::new(Point::new(0, 192), Point::new(0, 199))
-            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Black)
+                    .stroke_width(1)
+                    .build(),
+            )
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -113,7 +134,12 @@ mod tests {
         let mut display = Display1in54::default();
         display.set_rotation(DisplayRotation::Rotate180);
         let _ = Line::new(Point::new(192, 199), Point::new(199, 199))
-            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Black)
+                    .stroke_width(1)
+                    .build(),
+            )
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -133,7 +159,12 @@ mod tests {
         let mut display = Display1in54::default();
         display.set_rotation(DisplayRotation::Rotate270);
         let _ = Line::new(Point::new(199, 0), Point::new(199, 7))
-            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Black)
+                    .stroke_width(1)
+                    .build(),
+            )
             .draw(&mut display);
 
         let buffer = display.buffer();

--- a/src/epd1in54/graphics.rs
+++ b/src/epd1in54/graphics.rs
@@ -67,7 +67,7 @@ mod tests {
     use crate::graphics::{Display, DisplayRotation};
     use embedded_graphics::{
         prelude::*,
-        primitives::{Line, PrimitiveStyleBuilder},
+        primitives::{Line, PrimitiveStyle},
     };
 
     // test buffer length
@@ -90,12 +90,7 @@ mod tests {
     fn graphics_rotation_0() {
         let mut display = Display1in54::default();
         let _ = Line::new(Point::new(0, 0), Point::new(7, 0))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -112,12 +107,7 @@ mod tests {
         let mut display = Display1in54::default();
         display.set_rotation(DisplayRotation::Rotate90);
         let _ = Line::new(Point::new(0, 192), Point::new(0, 199))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -134,12 +124,7 @@ mod tests {
         let mut display = Display1in54::default();
         display.set_rotation(DisplayRotation::Rotate180);
         let _ = Line::new(Point::new(192, 199), Point::new(199, 199))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -159,12 +144,7 @@ mod tests {
         let mut display = Display1in54::default();
         display.set_rotation(DisplayRotation::Rotate270);
         let _ = Line::new(Point::new(199, 0), Point::new(199, 7))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();

--- a/src/epd1in54/mod.rs
+++ b/src/epd1in54/mod.rs
@@ -6,7 +6,7 @@
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
 //!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
 //!};
 //!use epd_waveshare::{epd1in54::*, prelude::*};
 //!#
@@ -26,8 +26,12 @@
 //!let mut display = Display1in54::default();
 //!
 //!// Use embedded graphics for drawing a line
+//!let style = PrimitiveStyleBuilder::new()
+//!    .stroke_color(Black)
+//!    .stroke_width(1)
+//!    .build();
 //!let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+//!    .into_styled(style)
 //!    .draw(&mut display);
 //!
 //!// Display updated frame

--- a/src/epd1in54b/graphics.rs
+++ b/src/epd1in54b/graphics.rs
@@ -21,7 +21,8 @@ impl Default for Display1in54b {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display1in54b {
+impl DrawTarget for Display1in54b {
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
     fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {

--- a/src/epd1in54b/graphics.rs
+++ b/src/epd1in54b/graphics.rs
@@ -1,7 +1,7 @@
 use crate::epd1in54b::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
-use embedded_graphics::prelude::*;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 1in54 EPD
 ///
@@ -25,10 +25,18 @@ impl DrawTarget for Display1in54b {
     type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display1in54b {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }

--- a/src/epd1in54c/graphics.rs
+++ b/src/epd1in54c/graphics.rs
@@ -1,7 +1,7 @@
 use crate::epd1in54c::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
-use embedded_graphics::prelude::*;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 1in54c EPD
 ///
@@ -24,10 +24,18 @@ impl DrawTarget for Display1in54c {
     type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display1in54c {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }

--- a/src/epd1in54c/graphics.rs
+++ b/src/epd1in54c/graphics.rs
@@ -20,7 +20,8 @@ impl Default for Display1in54c {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display1in54c {
+impl DrawTarget for Display1in54c {
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
     fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {

--- a/src/epd2in13_v2/graphics.rs
+++ b/src/epd2in13_v2/graphics.rs
@@ -2,7 +2,7 @@ use crate::buffer_len;
 use crate::epd2in13_v2::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
-use embedded_graphics::prelude::*;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 2in13 v2 EPD
 ///
@@ -23,13 +23,22 @@ impl Default for Display2in13 {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display2in13 {
+impl DrawTarget for Display2in13 {
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display2in13 {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }
@@ -59,7 +68,10 @@ mod tests {
     use crate::color::{Black, Color};
     use crate::epd2in13_v2;
     use crate::graphics::{Display, DisplayRotation};
-    use embedded_graphics::{primitives::Line, style::PrimitiveStyle};
+    use embedded_graphics::{
+        prelude::*,
+        primitives::{Line, PrimitiveStyleBuilder},
+    };
 
     // test buffer length
     #[test]
@@ -82,7 +94,12 @@ mod tests {
         let mut display = Display2in13::default();
 
         let _ = Line::new(Point::new(0, 0), Point::new(7, 0))
-            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Black)
+                    .stroke_width(1)
+                    .build(),
+            )
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -103,7 +120,12 @@ mod tests {
             Point::new(0, (WIDTH - 8) as i32),
             Point::new(0, (WIDTH - 1) as i32),
         )
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_color(Black)
+                .stroke_width(1)
+                .build(),
+        )
         .draw(&mut display);
 
         let buffer = display.buffer();
@@ -124,7 +146,12 @@ mod tests {
             Point::new((WIDTH - 8) as i32, (HEIGHT - 1) as i32),
             Point::new((WIDTH - 1) as i32, (HEIGHT - 1) as i32),
         )
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_color(Black)
+                .stroke_width(1)
+                .build(),
+        )
         .draw(&mut display);
 
         let buffer = display.buffer();
@@ -145,7 +172,12 @@ mod tests {
             Point::new((HEIGHT - 1) as i32, 0),
             Point::new((HEIGHT - 1) as i32, 7),
         )
-        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+        .into_styled(
+            PrimitiveStyleBuilder::new()
+                .stroke_color(Black)
+                .stroke_width(1)
+                .build(),
+        )
         .draw(&mut display);
 
         let buffer = display.buffer();

--- a/src/epd2in13_v2/graphics.rs
+++ b/src/epd2in13_v2/graphics.rs
@@ -70,7 +70,7 @@ mod tests {
     use crate::graphics::{Display, DisplayRotation};
     use embedded_graphics::{
         prelude::*,
-        primitives::{Line, PrimitiveStyleBuilder},
+        primitives::{Line, PrimitiveStyle},
     };
 
     // test buffer length
@@ -94,12 +94,7 @@ mod tests {
         let mut display = Display2in13::default();
 
         let _ = Line::new(Point::new(0, 0), Point::new(7, 0))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -120,12 +115,7 @@ mod tests {
             Point::new(0, (WIDTH - 8) as i32),
             Point::new(0, (WIDTH - 1) as i32),
         )
-        .into_styled(
-            PrimitiveStyleBuilder::new()
-                .stroke_color(Black)
-                .stroke_width(1)
-                .build(),
-        )
+        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
         .draw(&mut display);
 
         let buffer = display.buffer();
@@ -146,12 +136,7 @@ mod tests {
             Point::new((WIDTH - 8) as i32, (HEIGHT - 1) as i32),
             Point::new((WIDTH - 1) as i32, (HEIGHT - 1) as i32),
         )
-        .into_styled(
-            PrimitiveStyleBuilder::new()
-                .stroke_color(Black)
-                .stroke_width(1)
-                .build(),
-        )
+        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
         .draw(&mut display);
 
         let buffer = display.buffer();
@@ -172,12 +157,7 @@ mod tests {
             Point::new((HEIGHT - 1) as i32, 0),
             Point::new((HEIGHT - 1) as i32, 7),
         )
-        .into_styled(
-            PrimitiveStyleBuilder::new()
-                .stroke_color(Black)
-                .stroke_width(1)
-                .build(),
-        )
+        .into_styled(PrimitiveStyle::with_stroke(Black, 1))
         .draw(&mut display);
 
         let buffer = display.buffer();

--- a/src/epd2in13bc/graphics.rs
+++ b/src/epd2in13bc/graphics.rs
@@ -1,6 +1,6 @@
 use crate::color::TriColor;
 use crate::epd2in13bc::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
-use crate::graphics::{TriDisplay, DisplayRotation};
+use crate::graphics::{DisplayRotation, TriDisplay};
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 2.13" b/c EPD

--- a/src/epd2in13bc/graphics.rs
+++ b/src/epd2in13bc/graphics.rs
@@ -1,7 +1,7 @@
 use crate::color::TriColor;
 use crate::epd2in13bc::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
-use crate::graphics::{DisplayRotation, TriDisplay};
-use embedded_graphics::prelude::*;
+use crate::graphics::{TriDisplay, DisplayRotation};
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 2.13" b/c EPD
 ///
@@ -23,13 +23,21 @@ impl Default for Display2in13bc {
     }
 }
 
-impl DrawTarget<TriColor> for Display2in13bc {
+impl DrawTarget for Display2in13bc {
+    type Color = TriColor;
     type Error = core::convert::Infallible;
-
-    fn draw_pixel(&mut self, pixel: Pixel<TriColor>) -> Result<(), Self::Error> {
-        self.draw_helper_tri(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper_tri(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display2in13bc {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -7,8 +7,8 @@
 //!```rust, no_run
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
-//!use embedded_graphics::{prelude::*, primitives::Line, style::PrimitiveStyle};
-//!use epd_waveshare::{epd2in13bc::*, prelude::*, color::TriColor};
+//!use embedded_graphics::{prelude::*, primitives::{Line, PrimitiveStyle, PrimitiveStyleBuilder}};
+//!use epd_waveshare::{epd2in13bc::*, prelude::*};
 //!#
 //!# let expectations = [];
 //!# let mut spi = spi::Mock::new(&expectations);

--- a/src/epd2in7b/graphics.rs
+++ b/src/epd2in7b/graphics.rs
@@ -1,7 +1,7 @@
 use crate::epd2in7b::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
-use embedded_graphics::prelude::*;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 2in7B EPD
 ///
@@ -26,10 +26,18 @@ impl DrawTarget for Display2in7b {
     type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display2in7b {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }
@@ -61,7 +69,10 @@ mod tests {
     use crate::epd2in7b;
     use crate::epd2in7b::{HEIGHT, WIDTH};
     use crate::graphics::{Display, DisplayRotation};
-    use embedded_graphics::{primitives::Line, style::PrimitiveStyle};
+    use embedded_graphics::{
+        prelude::*,
+        primitives::{Line, PrimitiveStyle},
+    };
 
     // test buffer length
     #[test]

--- a/src/epd2in7b/graphics.rs
+++ b/src/epd2in7b/graphics.rs
@@ -22,7 +22,8 @@ impl Default for Display2in7b {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display2in7b {
+impl DrawTarget for Display2in7b {
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
     fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {

--- a/src/epd2in9/graphics.rs
+++ b/src/epd2in9/graphics.rs
@@ -36,6 +36,7 @@ impl DrawTarget for Display2in9 {
         Ok(())
     }
 }
+
 impl OriginDimensions for Display2in9 {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)

--- a/src/epd2in9/graphics.rs
+++ b/src/epd2in9/graphics.rs
@@ -1,7 +1,7 @@
 use crate::epd2in9::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
-use embedded_graphics::prelude::*;
+use embedded_graphics_core::prelude::*;
 
 /// Display with Fullsize buffer for use with the 2in9 EPD
 ///
@@ -22,13 +22,21 @@ impl Default for Display2in9 {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display2in9 {
+impl DrawTarget for Display2in9 {
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
-
+}
+impl OriginDimensions for Display2in9 {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }

--- a/src/epd2in9/mod.rs
+++ b/src/epd2in9/mod.rs
@@ -7,7 +7,7 @@
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
 //!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
 //!};
 //!use epd_waveshare::{epd2in9::*, prelude::*};
 //!#
@@ -27,8 +27,12 @@
 //!let mut display = Display2in9::default();
 //!
 //!// Use embedded graphics for drawing a line
+//!let style = PrimitiveStyleBuilder::new()
+//!  .stroke_color(Black)
+//!  .stroke_width(1)
+//!  .build();
 //!let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+//!    .into_styled(style)
 //!    .draw(&mut display);
 //!
 //!    // Display updated frame

--- a/src/epd2in9/mod.rs
+++ b/src/epd2in9/mod.rs
@@ -7,7 +7,7 @@
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
 //!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyle},
 //!};
 //!use epd_waveshare::{epd2in9::*, prelude::*};
 //!#
@@ -27,12 +27,8 @@
 //!let mut display = Display2in9::default();
 //!
 //!// Use embedded graphics for drawing a line
-//!let style = PrimitiveStyleBuilder::new()
-//!  .stroke_color(Black)
-//!  .stroke_width(1)
-//!  .build();
 //!let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-//!    .into_styled(style)
+//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
 //!    .draw(&mut display);
 //!
 //!    // Display updated frame

--- a/src/epd2in9_v2/graphics.rs
+++ b/src/epd2in9_v2/graphics.rs
@@ -1,6 +1,5 @@
 use crate::epd2in9::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
 
 /// Display with Fullsize buffer for use with the 2in9 EPD V2
@@ -22,7 +21,8 @@ impl Default for Display2in9 {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display2in9 {
+impl DrawTarget for Display2in9 {
+    type Color = BinaryColor
     type Error = core::convert::Infallible;
 
     fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {

--- a/src/epd2in9_v2/graphics.rs
+++ b/src/epd2in9_v2/graphics.rs
@@ -1,6 +1,7 @@
 use crate::epd2in9::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::prelude::*;
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::prelude::*;
 
 /// Display with Fullsize buffer for use with the 2in9 EPD V2
 ///
@@ -22,13 +23,21 @@ impl Default for Display2in9 {
 }
 
 impl DrawTarget for Display2in9 {
-    type Color = BinaryColor
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display2in9 {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }

--- a/src/epd2in9_v2/mod.rs
+++ b/src/epd2in9_v2/mod.rs
@@ -8,7 +8,7 @@
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
 //!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyle},
 //!};
 //!use epd_waveshare::{epd2in9_v2::*, prelude::*};
 //!#

--- a/src/epd2in9bc/graphics.rs
+++ b/src/epd2in9bc/graphics.rs
@@ -1,6 +1,7 @@
 use crate::epd2in9bc::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::prelude::*;
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 2in9b/c EPD
 ///
@@ -20,13 +21,21 @@ impl Default for Display2in9bc {
 }
 
 impl DrawTarget for Display2in9bc {
-    type Color = BinaryColor
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display2in9bc {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }

--- a/src/epd2in9bc/graphics.rs
+++ b/src/epd2in9bc/graphics.rs
@@ -1,6 +1,5 @@
 use crate::epd2in9bc::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
 
 /// Full size buffer for use with the 2in9b/c EPD
@@ -20,7 +19,8 @@ impl Default for Display2in9bc {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display2in9bc {
+impl DrawTarget for Display2in9bc {
+    type Color = BinaryColor
     type Error = core::convert::Infallible;
 
     fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {

--- a/src/epd2in9bc/mod.rs
+++ b/src/epd2in9bc/mod.rs
@@ -6,7 +6,7 @@
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
 //!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyle},
 //!};
 //!use epd_waveshare::{epd2in9bc::*, prelude::*};
 //!#

--- a/src/epd4in2/graphics.rs
+++ b/src/epd4in2/graphics.rs
@@ -69,7 +69,7 @@ mod tests {
     use crate::graphics::{Display, DisplayRotation};
     use embedded_graphics::{
         prelude::*,
-        primitives::{Line, PrimitiveStyleBuilder},
+        primitives::{Line, PrimitiveStyle},
     };
 
     // test buffer length
@@ -92,12 +92,7 @@ mod tests {
     fn graphics_rotation_0() {
         let mut display = Display4in2::default();
         let _ = Line::new(Point::new(0, 0), Point::new(7, 0))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -114,12 +109,7 @@ mod tests {
         let mut display = Display4in2::default();
         display.set_rotation(DisplayRotation::Rotate90);
         let _ = Line::new(Point::new(0, 392), Point::new(0, 399))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -137,12 +127,7 @@ mod tests {
         display.set_rotation(DisplayRotation::Rotate180);
 
         let _ = Line::new(Point::new(392, 299), Point::new(399, 299))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -162,12 +147,7 @@ mod tests {
         let mut display = Display4in2::default();
         display.set_rotation(DisplayRotation::Rotate270);
         let _ = Line::new(Point::new(299, 0), Point::new(299, 7))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();

--- a/src/epd4in2/graphics.rs
+++ b/src/epd4in2/graphics.rs
@@ -1,7 +1,7 @@
 use crate::epd4in2::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
-use embedded_graphics::prelude::*;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 4in2 EPD
 ///
@@ -22,13 +22,21 @@ impl Default for Display4in2 {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display4in2 {
+impl DrawTarget for Display4in2 {
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
-
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display4in2 {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }
@@ -59,7 +67,10 @@ mod tests {
     use crate::color::Color;
     use crate::epd4in2;
     use crate::graphics::{Display, DisplayRotation};
-    use embedded_graphics::{primitives::Line, style::PrimitiveStyle};
+    use embedded_graphics::{
+        prelude::*,
+        primitives::{Line, PrimitiveStyleBuilder},
+    };
 
     // test buffer length
     #[test]
@@ -81,7 +92,12 @@ mod tests {
     fn graphics_rotation_0() {
         let mut display = Display4in2::default();
         let _ = Line::new(Point::new(0, 0), Point::new(7, 0))
-            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Black)
+                    .stroke_width(1)
+                    .build(),
+            )
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -98,7 +114,12 @@ mod tests {
         let mut display = Display4in2::default();
         display.set_rotation(DisplayRotation::Rotate90);
         let _ = Line::new(Point::new(0, 392), Point::new(0, 399))
-            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Black)
+                    .stroke_width(1)
+                    .build(),
+            )
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -116,7 +137,12 @@ mod tests {
         display.set_rotation(DisplayRotation::Rotate180);
 
         let _ = Line::new(Point::new(392, 299), Point::new(399, 299))
-            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Black)
+                    .stroke_width(1)
+                    .build(),
+            )
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -136,7 +162,12 @@ mod tests {
         let mut display = Display4in2::default();
         display.set_rotation(DisplayRotation::Rotate270);
         let _ = Line::new(Point::new(299, 0), Point::new(299, 7))
-            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+            .into_styled(
+                PrimitiveStyleBuilder::new()
+                    .stroke_color(Black)
+                    .stroke_width(1)
+                    .build(),
+            )
             .draw(&mut display);
 
         let buffer = display.buffer();

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -11,7 +11,7 @@
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
 //!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
 //!};
 //!use epd_waveshare::{epd4in2::*, prelude::*};
 //!#
@@ -31,8 +31,12 @@
 //!let mut display = Display4in2::default();
 //!
 //!// Use embedded graphics for drawing a line
+//!let style = PrimitiveStyleBuilder::new()
+//!    .stroke_color(Black)
+//!    .stroke_width(1)
+//!    .build();
 //!let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+//!    .into_styled(style)
 //!    .draw(&mut display);
 //!
 //!    // Display updated frame

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -11,7 +11,7 @@
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
 //!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyle},
 //!};
 //!use epd_waveshare::{epd4in2::*, prelude::*};
 //!#
@@ -31,12 +31,8 @@
 //!let mut display = Display4in2::default();
 //!
 //!// Use embedded graphics for drawing a line
-//!let style = PrimitiveStyleBuilder::new()
-//!    .stroke_color(Black)
-//!    .stroke_width(1)
-//!    .build();
 //!let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-//!    .into_styled(style)
+//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
 //!    .draw(&mut display);
 //!
 //!    // Display updated frame

--- a/src/epd5in65f/graphics.rs
+++ b/src/epd5in65f/graphics.rs
@@ -1,7 +1,7 @@
 use crate::color::OctColor;
 use crate::epd5in65f::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{DisplayRotation, OctDisplay};
-use embedded_graphics::prelude::*;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 5in65f EPD
 ///
@@ -26,10 +26,18 @@ impl DrawTarget for Display5in65f {
     type Color = OctColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<OctColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display5in65f {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }
@@ -58,7 +66,10 @@ mod tests {
     use super::*;
     use crate::epd5in65f;
     use crate::graphics::{DisplayRotation, OctDisplay};
-    use embedded_graphics::{primitives::Line, style::PrimitiveStyle};
+    use embedded_graphics::{
+        prelude::*,
+        primitives::{Line, PrimitiveStyle},
+    };
 
     // test buffer length
     #[test]

--- a/src/epd5in65f/graphics.rs
+++ b/src/epd5in65f/graphics.rs
@@ -22,7 +22,8 @@ impl Default for Display5in65f {
     }
 }
 
-impl DrawTarget<OctColor> for Display5in65f {
+impl DrawTarget for Display5in65f {
+    type Color = OctColor;
     type Error = core::convert::Infallible;
 
     fn draw_pixel(&mut self, pixel: Pixel<OctColor>) -> Result<(), Self::Error> {

--- a/src/epd7in5/graphics.rs
+++ b/src/epd7in5/graphics.rs
@@ -22,7 +22,8 @@ impl Default for Display7in5 {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display7in5 {
+impl DrawTarget for Display7in5 {
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
     fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {

--- a/src/epd7in5/graphics.rs
+++ b/src/epd7in5/graphics.rs
@@ -1,7 +1,7 @@
 use crate::epd7in5::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
-use embedded_graphics::prelude::*;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 7in5 EPD
 ///
@@ -26,10 +26,18 @@ impl DrawTarget for Display7in5 {
     type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display7in5 {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }
@@ -60,7 +68,10 @@ mod tests {
     use crate::color::Color;
     use crate::epd7in5;
     use crate::graphics::{Display, DisplayRotation};
-    use embedded_graphics::{primitives::Line, style::PrimitiveStyle};
+    use embedded_graphics::{
+        prelude::*,
+        primitives::{Line, PrimitiveStyle},
+    };
 
     // test buffer length
     #[test]

--- a/src/epd7in5_hd/graphics.rs
+++ b/src/epd7in5_hd/graphics.rs
@@ -22,7 +22,8 @@ impl Default for Display7in5 {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display7in5 {
+impl DrawTarget for Display7in5 {
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
     fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {

--- a/src/epd7in5_hd/graphics.rs
+++ b/src/epd7in5_hd/graphics.rs
@@ -1,7 +1,7 @@
 use crate::epd7in5_hd::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
-use embedded_graphics::prelude::*;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 7in5 EPD
 ///
@@ -26,10 +26,18 @@ impl DrawTarget for Display7in5 {
     type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
     }
+}
 
+impl OriginDimensions for Display7in5 {
     fn size(&self) -> Size {
         Size::new(WIDTH, HEIGHT)
     }
@@ -59,7 +67,10 @@ mod tests {
     use crate::color::{Black, Color};
     use crate::epd7in5_hd;
     use crate::graphics::{Display, DisplayRotation};
-    use embedded_graphics::{primitives::Line, style::PrimitiveStyle};
+    use embedded_graphics::{
+        prelude::*,
+        primitives::{Line, PrimitiveStyle},
+    };
 
     // test buffer length
     #[test]

--- a/src/epd7in5_v2/graphics.rs
+++ b/src/epd7in5_v2/graphics.rs
@@ -30,10 +30,6 @@ impl DrawTarget for Display7in5 {
     fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
         self.draw_helper(WIDTH, HEIGHT, pixel)
     }
-
-//     fn size(&self) -> Size {
-//        Size::new(WIDTH, HEIGHT)
-//    }
 }
 
 impl Display for Display7in5 {

--- a/src/epd7in5_v2/graphics.rs
+++ b/src/epd7in5_v2/graphics.rs
@@ -2,6 +2,7 @@ use crate::epd7in5_v2::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;
+use embedded_graphics_core::OriginDimension;
 
 /// Full size buffer for use with the 7in5 EPD
 ///
@@ -22,16 +23,17 @@ impl Default for Display7in5 {
     }
 }
 
-impl DrawTarget<BinaryColor> for Display7in5 {
+impl DrawTarget for Display7in5 {
+    type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
     fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
         self.draw_helper(WIDTH, HEIGHT, pixel)
     }
 
-    fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
-    }
+//     fn size(&self) -> Size {
+//        Size::new(WIDTH, HEIGHT)
+//    }
 }
 
 impl Display for Display7in5 {
@@ -49,6 +51,12 @@ impl Display for Display7in5 {
 
     fn rotation(&self) -> DisplayRotation {
         self.rotation
+    }
+}
+
+impl OriginDimension for Display7in5 {
+     fn size(&self) -> Size {
+        Size::new(WIDTH, HEIGHT)
     }
 }
 

--- a/src/epd7in5_v2/graphics.rs
+++ b/src/epd7in5_v2/graphics.rs
@@ -1,8 +1,7 @@
 use crate::epd7in5_v2::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
 use embedded_graphics::pixelcolor::BinaryColor;
-use embedded_graphics::prelude::*;
-use embedded_graphics_core::OriginDimension;
+use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 7in5 EPD
 ///
@@ -27,8 +26,20 @@ impl DrawTarget for Display7in5 {
     type Color = BinaryColor;
     type Error = core::convert::Infallible;
 
-    fn draw_pixel(&mut self, pixel: Pixel<BinaryColor>) -> Result<(), Self::Error> {
-        self.draw_helper(WIDTH, HEIGHT, pixel)
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper(WIDTH, HEIGHT, pixel)?;
+        }
+        Ok(())
+    }
+}
+
+impl OriginDimensions for Display7in5 {
+    fn size(&self) -> Size {
+        Size::new(WIDTH, HEIGHT)
     }
 }
 
@@ -50,19 +61,16 @@ impl Display for Display7in5 {
     }
 }
 
-impl OriginDimension for Display7in5 {
-     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::color::{Black, Color};
     use crate::epd7in5_v2;
     use crate::graphics::{Display, DisplayRotation};
-    use embedded_graphics::{primitives::Line, style::PrimitiveStyle};
+    use embedded_graphics::{
+        prelude::*,
+        primitives::{Line, PrimitiveStyle},
+    };
 
     // test buffer length
     #[test]

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -241,7 +241,7 @@ pub trait OctDisplay: DrawTarget<Color = OctColor> {
 /// # use epd_waveshare::graphics::VarDisplay;
 /// # use epd_waveshare::color::Black;
 /// # use embedded_graphics::prelude::*;
-/// # use embedded_graphics::primitives::{Circle, Line, PrimitiveStyleBuilder};
+/// # use embedded_graphics::primitives::{Circle, Line, PrimitiveStyle};
 /// let width = 128;
 /// let height = 296;
 ///
@@ -250,13 +250,8 @@ pub trait OctDisplay: DrawTarget<Color = OctColor> {
 ///
 /// display.set_rotation(DisplayRotation::Rotate90);
 ///
-///let style = PrimitiveStyleBuilder::new()
-///  .stroke_color(Black)
-///  .stroke_width(1)
-///  .build();
-///
 /// let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-///         .into_styled(style)
+///         .into_styled(PrimitiveStyle::with_stroke(Black, 1))
 ///         .draw(&mut display);
 /// ```
 pub struct VarDisplay<'a> {
@@ -395,7 +390,7 @@ mod tests {
     use crate::color::Color;
     use embedded_graphics::{
         prelude::*,
-        primitives::{Line, PrimitiveStyleBuilder},
+        primitives::{Line, PrimitiveStyle},
     };
 
     #[test]
@@ -453,12 +448,7 @@ mod tests {
         let mut display = VarDisplay::new(width, height, &mut buffer);
 
         let _ = Line::new(Point::new(0, 0), Point::new(7, 0))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();
@@ -482,12 +472,7 @@ mod tests {
         display.set_rotation(DisplayRotation::Rotate90);
 
         let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-            .into_styled(
-                PrimitiveStyleBuilder::new()
-                    .stroke_color(Black)
-                    .stroke_width(1)
-                    .build(),
-            )
+            .into_styled(PrimitiveStyle::with_stroke(Black, 1))
             .draw(&mut display);
 
         let buffer = display.buffer();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
 //!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
 //!};
 //!use epd_waveshare::{epd1in54::*, prelude::*};
 //!#
@@ -34,8 +34,14 @@
 //!let mut display = Display1in54::default();
 //!
 //!// Use embedded graphics for drawing a line
+//!
+//!let style = PrimitiveStyleBuilder::new()
+//!  .stroke_color(Black)
+//!  .stroke_width(1)
+//!  .build();
+//!
 //!let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+//!    .into_styled(style)
 //!    .draw(&mut display);
 //!
 //!    // Display updated frame
@@ -73,19 +79,19 @@ pub mod color;
 mod interface;
 
 pub mod epd1in54;
-pub mod epd1in54b;
-pub mod epd1in54c;
+//pub mod epd1in54b;
+//pub mod epd1in54c;
 pub mod epd2in13_v2;
 pub mod epd2in13bc;
-pub mod epd2in7b;
+//pub mod epd2in7b;
 pub mod epd2in9;
-pub mod epd2in9_v2;
-pub mod epd2in9bc;
+//pub mod epd2in9_v2;
+//pub mod epd2in9bc;
 pub mod epd4in2;
-pub mod epd5in65f;
-pub mod epd7in5;
-pub mod epd7in5_hd;
-pub mod epd7in5_v2;
+//pub mod epd5in65f;
+//pub mod epd7in5;
+//pub mod epd7in5_hd;
+//pub mod epd7in5_v2;
 
 pub(crate) mod type_a;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!# use embedded_hal_mock::*;
 //!# fn main() -> Result<(), MockError> {
 //!use embedded_graphics::{
-//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
+//!    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyle},
 //!};
 //!use epd_waveshare::{epd1in54::*, prelude::*};
 //!#
@@ -35,13 +35,8 @@
 //!
 //!// Use embedded graphics for drawing a line
 //!
-//!let style = PrimitiveStyleBuilder::new()
-//!  .stroke_color(Black)
-//!  .stroke_width(1)
-//!  .build();
-//!
 //!let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-//!    .into_styled(style)
+//!    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
 //!    .draw(&mut display);
 //!
 //!    // Display updated frame

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,19 +74,19 @@ pub mod color;
 mod interface;
 
 pub mod epd1in54;
-//pub mod epd1in54b;
-//pub mod epd1in54c;
+pub mod epd1in54b;
+pub mod epd1in54c;
 pub mod epd2in13_v2;
 pub mod epd2in13bc;
-//pub mod epd2in7b;
+pub mod epd2in7b;
 pub mod epd2in9;
-//pub mod epd2in9_v2;
-//pub mod epd2in9bc;
+pub mod epd2in9_v2;
+pub mod epd2in9bc;
 pub mod epd4in2;
-//pub mod epd5in65f;
-//pub mod epd7in5;
-//pub mod epd7in5_hd;
-//pub mod epd7in5_v2;
+pub mod epd5in65f;
+pub mod epd7in5;
+pub mod epd7in5_hd;
+pub mod epd7in5_v2;
 
 pub(crate) mod type_a;
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -92,7 +92,7 @@ where
 ///# use embedded_hal_mock::*;
 ///# fn main() -> Result<(), MockError> {
 ///use embedded_graphics::{
-///    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+///    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
 ///};
 ///use epd_waveshare::{epd4in2::*, prelude::*};
 ///#
@@ -112,8 +112,14 @@ where
 ///let mut display = Display4in2::default();
 ///
 ///// Use embedded graphics for drawing a line
+///
+///let style = PrimitiveStyleBuilder::new()
+///  .stroke_color(Black)
+///  .stroke_width(1)
+///  .build();
+///
 ///let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-///    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
+///    .into_styled(style)
 ///    .draw(&mut display);
 ///
 ///    // Display updated frame
@@ -248,7 +254,7 @@ where
 ///# use embedded_hal_mock::*;
 ///# fn main() -> Result<(), MockError> {
 ///# use embedded_graphics::{
-///#   pixelcolor::BinaryColor::On as Black, prelude::*, primitives::Line, style::PrimitiveStyle,
+///#   pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
 ///# };
 ///# use epd_waveshare::{epd4in2::*, prelude::*};
 ///# use epd_waveshare::graphics::VarDisplay;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -92,7 +92,7 @@ where
 ///# use embedded_hal_mock::*;
 ///# fn main() -> Result<(), MockError> {
 ///use embedded_graphics::{
-///    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
+///    pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyle},
 ///};
 ///use epd_waveshare::{epd4in2::*, prelude::*};
 ///#
@@ -113,13 +113,8 @@ where
 ///
 ///// Use embedded graphics for drawing a line
 ///
-///let style = PrimitiveStyleBuilder::new()
-///  .stroke_color(Black)
-///  .stroke_width(1)
-///  .build();
-///
 ///let _ = Line::new(Point::new(0, 120), Point::new(0, 295))
-///    .into_styled(style)
+///    .into_styled(PrimitiveStyle::with_stroke(Black, 1))
 ///    .draw(&mut display);
 ///
 ///    // Display updated frame
@@ -254,7 +249,7 @@ where
 ///# use embedded_hal_mock::*;
 ///# fn main() -> Result<(), MockError> {
 ///# use embedded_graphics::{
-///#   pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyleBuilder},
+///#   pixelcolor::BinaryColor::On as Black, prelude::*, primitives::{Line, PrimitiveStyle},
 ///# };
 ///# use epd_waveshare::{epd4in2::*, prelude::*};
 ///# use epd_waveshare::graphics::VarDisplay;


### PR DESCRIPTION
I've started to migrate to embedded-graphics 0.7.0

First a minimum set of drivers to make tests pass. @caemor could you review to see if this is the way you want to go forward? I'll then update the other drivers