### PR TITLE
Provide full QuickRefresh interface for 4.2 inch display

### DIFF
--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -1,5 +1,5 @@
 //! A simple Driver for the Waveshare 2.13" (B/C) E-Ink Display via SPI
-//! More information on this display can be found at the [Waveshare Wiki]:(https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT_(B))
+//! More information on this display can be found at the [Waveshare Wiki](https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT_(B))
 //! This driver was build and tested for 212x104, 2.13inch E-Ink display HAT for Raspberry Pi, three-color, SPI interface
 //!
 //! # Example for the 2.13" E-Ink Display

--- a/src/epd2in9_v2/mod.rs
+++ b/src/epd2in9_v2/mod.rs
@@ -1,6 +1,6 @@
 //! A simple Driver for the Waveshare 2.9" E-Ink Display V2 via SPI
 //!
-//! Specification: https://www.waveshare.com/w/upload/7/79/2.9inch-e-paper-v2-specification.pdf
+//! Specification: <https://www.waveshare.com/w/upload/7/79/2.9inch-e-paper-v2-specification.pdf>
 //!
 //! # Example for the 2.9 in E-Ink Display V2
 //!

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -482,7 +482,7 @@ where
         Ok(())
     }
 
-    /// This is wrapper around `display_frame` for using this device as a true
+    /// This is a wrapper around `display_frame` for using this device as a true
     /// `QuickRefresh` device.
     fn display_new_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         self.display_frame(spi, delay)

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -482,21 +482,24 @@ where
         Ok(())
     }
 
-    /// This function is not needed for this display
-    #[allow(unused)]
+    /// This is wrapper around `display_frame` for using this device as a true
+    /// `QuickRefresh` device.
     fn display_new_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
-        unimplemented!()
+        self.display_frame(spi, delay)
     }
 
-    /// This function is not needed for this display
-    #[allow(unused)]
+    /// This is wrapper around `update_new_frame` and `display_frame` for using
+    /// this device as a true `QuickRefresh` device.
+    ///
+    /// To be used immediately after `update_old_frame`.
     fn update_and_display_new_frame(
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
         delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        unimplemented!()
+        self.update_new_frame(spi, buffer, delay)?;
+        self.display_frame(spi, delay)
     }
 
     fn update_partial_old_frame(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,9 +109,9 @@ pub mod prelude {
 ///  unused
 ///  bits        width
 /// <----><------------------------>
-/// [XXXXX210][76543210]...[76543210] ^
-/// [XXXXX210][76543210]...[76543210] | height
-/// [XXXXX210][76543210]...[76543210] v
+/// \[XXXXX210\]\[76543210\]...\[76543210\] ^
+/// \[XXXXX210\]\[76543210\]...\[76543210\] | height
+/// \[XXXXX210\]\[76543210\]...\[76543210\] v
 pub const fn buffer_len(width: usize, height: usize) -> usize {
     (width + 7) / 8 * height
 }


### PR DESCRIPTION
The Waveshare 4.2 inch display needs no special commands for displaying the new frame. But it will come in handy to support the full `QuickRefresh` trait when it comes to supporting different quick refresh capable displays from an application.

This PR implements `display_new_frame` and `update_and_display_new_frame` using the already existing methods. It also brings some cleanup to warnings from `cargo doc` which showed up when checking the docs for the newly implemented methods.

