### PR TITLE
Make embedded-graphics a dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,19 +16,19 @@ edition = "2018"
 # travis-ci = { repository = "caemor/epd-waveshare" }
 
 [dependencies]
-embedded-graphics = { version = "0.7.1", optional = true}
 embedded-graphics-core = { version = "0.3.2", optional = true}
 embedded-hal = {version = "0.2.4", features = ["unproven"]}
 bit_field = "0.10.1"
 
 [dev-dependencies]
+embedded-graphics = "0.7.1"
 linux-embedded-hal = "0.3"
 embedded-hal-mock = "0.7"
 
 [features]
 default = ["graphics"]
 
-graphics = ["embedded-graphics","embedded-graphics-core"]
+graphics = ["embedded-graphics-core"]
 
 # Offers an alternative fast full lut for type_a displays, but the refreshed screen isnt as clean looking
 type_a_alternative_faster_lut = []

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,9 +1,9 @@
 //! B/W Color for EPDs
 
 #[cfg(feature = "graphics")]
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 #[cfg(feature = "graphics")]
-use embedded_graphics::pixelcolor::PixelColor;
+use embedded_graphics_core::pixelcolor::PixelColor;
 
 #[cfg(feature = "graphics")]
 pub use BinaryColor::Off as White;

--- a/src/epd1in54/graphics.rs
+++ b/src/epd1in54/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd1in54::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 1in54 EPD

--- a/src/epd1in54b/graphics.rs
+++ b/src/epd1in54b/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd1in54b::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 1in54 EPD

--- a/src/epd1in54c/graphics.rs
+++ b/src/epd1in54c/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd1in54c::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 1in54c EPD

--- a/src/epd2in13_v2/graphics.rs
+++ b/src/epd2in13_v2/graphics.rs
@@ -1,7 +1,7 @@
 use crate::buffer_len;
 use crate::epd2in13_v2::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 2in13 v2 EPD

--- a/src/epd2in7b/graphics.rs
+++ b/src/epd2in7b/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd2in7b::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 2in7B EPD

--- a/src/epd2in9/graphics.rs
+++ b/src/epd2in9/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd2in9::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Display with Fullsize buffer for use with the 2in9 EPD

--- a/src/epd2in9_v2/graphics.rs
+++ b/src/epd2in9_v2/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd2in9::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Display with Fullsize buffer for use with the 2in9 EPD V2

--- a/src/epd2in9bc/graphics.rs
+++ b/src/epd2in9bc/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd2in9bc::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BITS, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 2in9b/c EPD

--- a/src/epd4in2/graphics.rs
+++ b/src/epd4in2/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd4in2::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 4in2 EPD

--- a/src/epd7in5/graphics.rs
+++ b/src/epd7in5/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd7in5::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 7in5 EPD

--- a/src/epd7in5_hd/graphics.rs
+++ b/src/epd7in5_hd/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd7in5_hd::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 7in5 EPD

--- a/src/epd7in5_v2/graphics.rs
+++ b/src/epd7in5_v2/graphics.rs
@@ -1,6 +1,6 @@
 use crate::epd7in5_v2::{DEFAULT_BACKGROUND_COLOR, HEIGHT, WIDTH};
 use crate::graphics::{Display, DisplayRotation};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Full size buffer for use with the 7in5 EPD

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -2,7 +2,7 @@
 
 use crate::buffer_len;
 use crate::color::{Color, OctColor, TriColor};
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 use embedded_graphics_core::prelude::*;
 
 /// Displayrotation


### PR DESCRIPTION
e-g-core should be the only e-g dependency required for the driver itself, so this PR changes `Cargo.toml` and a few of the imports to reflect that.

Let me know if you want me to merge the imports and I'll do another pass to fix that up.