### PR TITLE
Add Color Conversions, Allow Changing Display Background Color

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,9 +1,9 @@
 //! B/W Color for EPDs
 
 #[cfg(feature = "graphics")]
-use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics_core::pixelcolor::BinaryColor;
 #[cfg(feature = "graphics")]
-use embedded_graphics::pixelcolor::PixelColor;
+use embedded_graphics_core::pixelcolor::PixelColor;
 
 #[cfg(feature = "graphics")]
 pub use BinaryColor::Off as White;
@@ -83,7 +83,7 @@ impl From<BinaryColor> for OctColor {
 }
 
 #[cfg(feature = "graphics")]
-impl From<OctColor> for embedded_graphics::pixelcolor::Rgb888 {
+impl From<OctColor> for embedded_graphics_core::pixelcolor::Rgb888 {
     fn from(b: OctColor) -> Self {
         let (r, b, g) = b.rgb();
         Self::new(r, b, g)
@@ -91,9 +91,9 @@ impl From<OctColor> for embedded_graphics::pixelcolor::Rgb888 {
 }
 
 #[cfg(feature = "graphics")]
-impl From<embedded_graphics::pixelcolor::Rgb888> for OctColor {
-    fn from(p: embedded_graphics::pixelcolor::Rgb888) -> OctColor {
-        use embedded_graphics::prelude::RgbColor;
+impl From<embedded_graphics_core::pixelcolor::Rgb888> for OctColor {
+    fn from(p: embedded_graphics_core::pixelcolor::Rgb888) -> OctColor {
+        use embedded_graphics_core::prelude::RgbColor;
         let colors = [
             OctColor::Black,
             OctColor::White,
@@ -126,16 +126,16 @@ impl From<embedded_graphics::pixelcolor::Rgb888> for OctColor {
 }
 
 #[cfg(feature = "graphics")]
-impl From<embedded_graphics::pixelcolor::raw::RawU4> for OctColor {
-    fn from(b: embedded_graphics::pixelcolor::raw::RawU4) -> Self {
-        use embedded_graphics::prelude::RawData;
+impl From<embedded_graphics_core::pixelcolor::raw::RawU4> for OctColor {
+    fn from(b: embedded_graphics_core::pixelcolor::raw::RawU4) -> Self {
+        use embedded_graphics_core::prelude::RawData;
         OctColor::from_nibble(b.into_inner()).unwrap()
     }
 }
 
 #[cfg(feature = "graphics")]
 impl PixelColor for OctColor {
-    type Raw = embedded_graphics::pixelcolor::raw::RawU4;
+    type Raw = embedded_graphics_core::pixelcolor::raw::RawU4;
 }
 
 impl OctColor {

--- a/src/color.rs
+++ b/src/color.rs
@@ -114,9 +114,9 @@ impl From<embedded_graphics_core::pixelcolor::Rgb888> for OctColor {
             .iter()
             .map(|c| (c, c.rgb()))
             .map(|(c, (r, g, b))| {
-                let dist = ((r - p.r()) as u32).pow(2)
-                    + ((g - p.g()) as u32).pow(2)
-                    + ((b - p.b()) as u32).pow(2);
+                let dist = (i32::from(r) - i32::from(p.r())).pow(2)
+                    + (i32::from(g) - i32::from(p.g())).pow(2)
+                    + (i32::from(b) - i32::from(p.b())).pow(2);
                 (c, dist)
             })
             .min_by_key(|(_c, dist)| *dist)


### PR DESCRIPTION
Adds some useful color conversions implementations so it's easier to work with the `image` and `embedded-graphics` crate.

Allow setting display background color (i.e. the border around the display), which I only recently realized was an option.