### PR TITLE
Fix pins for epd2in13_v2 example (#90)

### DIFF
--- a/examples/epd2in13_v2.rs
+++ b/examples/epd2in13_v2.rs
@@ -41,19 +41,19 @@ fn main() -> Result<(), std::io::Error> {
     cs.set_direction(Direction::Out).expect("CS Direction");
     cs.set_value(1).expect("CS Value set to 1");
 
-    let busy = Pin::new(5); //pin 29
+    let busy = Pin::new(24); // GPIO 24, board J-18
     busy.export().expect("busy export");
     while !busy.is_exported() {}
     busy.set_direction(Direction::In).expect("busy Direction");
     //busy.set_value(1).expect("busy Value set to 1");
 
-    let dc = Pin::new(6); //pin 31 //bcm6
+    let dc = Pin::new(25); // GPIO 25, board J-22
     dc.export().expect("dc export");
     while !dc.is_exported() {}
     dc.set_direction(Direction::Out).expect("dc Direction");
     dc.set_value(1).expect("dc Value set to 1");
 
-    let rst = Pin::new(16); //pin 36 //bcm16
+    let rst = Pin::new(17); // GPIO 17, board J-11
     rst.export().expect("rst export");
     while !rst.is_exported() {}
     rst.set_direction(Direction::Out).expect("rst Direction");

--- a/examples/epd2in13_v2.rs
+++ b/examples/epd2in13_v2.rs
@@ -19,6 +19,7 @@ use linux_embedded_hal::{
     Delay, Pin, Spidev,
 };
 
+// The pins in this example are for the Universal e-Paper Raw Panel Driver HAT
 // activate spi, gpio in raspi-config
 // needs to be run with sudo because of some sysfs_gpio permission problems and follow-up timing problems
 // see https://github.com/rust-embedded/rust-sysfs-gpio/issues/5 and follow-up issues


### PR DESCRIPTION
This should fix Issue #90 

The gpio pin numbers used in  `examples/epd2in13_v2.rs` do not work when connecting the display directly via the built-in gpio-header.

As suggested by @lrbalt the pins of `examples/epd2in13bc.rs` do work correctly. Thanks for the idea!

Successfully tested with a Raspberry Pi 4 and Pi Zero.