### PR TITLE
Allow non linux dev builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Made Examples and Linux embedded hal optional (linux only) and therefore allowed building on other hosts (#101, #94)
+
 ### Fixed
 
 ## [v0.5.0] - 2021-11-28

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-[package]
+ [package]
 authors = ["Christoph Groß <caemor@mailbox.org>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "An embedded-hal based driver for ePaper displays from Waveshare formerly published as eink-waveshare-rs"
@@ -22,13 +22,38 @@ bit_field = "0.10.1"
 
 [dev-dependencies]
 embedded-graphics = "0.7.1"
-linux-embedded-hal = "0.3"
+
 embedded-hal-mock = "0.8"
 
+[target.'cfg(unix)'.dev-dependencies]
+linux-embedded-hal = "0.3"
+
+[[example]]
+name = "epd1in54_no_graphics"
+required-features = ["linux-dev"]
+
+[[example]]
+name = "epd2in13_v2"
+required-features = ["linux-dev"]
+
+[[example]]
+name = "epd2in13bc"
+required-features = ["linux-dev"]
+
+[[example]]
+name = "epd4in2_variable_size"
+required-features = ["linux-dev"]
+
+[[example]]
+name = "epd4in2"
+required-features = ["linux-dev"]
+
 [features]
-default = ["graphics"]
+# Remove the linux-dev feature to build the tests on non  unix systems
+default = ["graphics", "linux-dev"]
 
 graphics = ["embedded-graphics-core"]
+linux-dev = []
 
 # Offers an alternative fast full lut for type_a displays, but the refreshed screen isnt as clean looking
 type_a_alternative_faster_lut = []

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <a href="https://github.com/caemor/epd-waveshare"><img src="https://github.com/caemor/epd-waveshare/actions/workflows/main.yml/badge.svg" alt="Github CI"></a>
+    <a href="https://github.com/caemor/epd-waveshare"><img src="https://github.com/caemor/epd-waveshare/actions/workflows/rust.yml/badge.svg" alt="Github CI"></a>
     <a href="https://crates.io/crates/epd-waveshare"><img src="https://img.shields.io/crates/v/epd-waveshare.svg" alt="Crates.io"></a>
     <a href="https://docs.rs/epd-waveshare"><img src="https://docs.rs/epd-waveshare/badge.svg" alt="Docs.rs"></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-[![Build Status](https://travis-ci.com/caemor/epd-waveshare.svg?branch=master)](https://travis-ci.com/caemor/epd-waveshare)
+<p align="center">
+    <a href="https://github.com/caemor/epd-waveshare"><img src="https://github.com/caemor/epd-waveshare/actions/workflows/main.yml/badge.svg" alt="Github CI"></a>
+    <a href="https://crates.io/crates/epd-waveshare"><img src="https://img.shields.io/crates/v/epd-waveshare.svg" alt="Crates.io"></a>
+    <a href="https://docs.rs/epd-waveshare"><img src="https://docs.rs/epd-waveshare/badge.svg" alt="Docs.rs"></a>
+</p>
+
+# EPD Driver
 
 This library contains a driver for E-Paper Modules from Waveshare (which are basically the same as the Dalian Good
 Display ones).

--- a/src/epd2in13_v2/command.rs
+++ b/src/epd2in13_v2/command.rs
@@ -133,8 +133,7 @@ impl DisplayUpdateControl2 {
     }
 }
 
-#[allow(dead_code)]
-
+#[allow(dead_code, clippy::enum_variant_names)]
 pub(crate) enum DataEntryModeIncr {
     XDecrYDecr = 0x0,
     XIncrYDecr = 0x1,
@@ -143,7 +142,6 @@ pub(crate) enum DataEntryModeIncr {
 }
 
 #[allow(dead_code)]
-
 pub(crate) enum DataEntryModeDir {
     XDir = 0x0,
     YDir = 0x4,


### PR DESCRIPTION
Some small fixes mostly for building and testing epd waveshare on non linux devices.
Also added links to the docs, crates.io and a CI Status

Fixes #94 