### PR TITLE
Fix width and height returned by size() when displays are rotated 90° and 270°

### DIFF
--- a/src/epd1in54/graphics.rs
+++ b/src/epd1in54/graphics.rs
@@ -39,7 +39,8 @@ impl DrawTarget for Display1in54 {
 
 impl OriginDimensions for Display1in54 {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -50,6 +51,13 @@ impl Display for Display1in54 {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd1in54b/graphics.rs
+++ b/src/epd1in54b/graphics.rs
@@ -38,7 +38,8 @@ impl DrawTarget for Display1in54b {
 
 impl OriginDimensions for Display1in54b {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -49,6 +50,13 @@ impl Display for Display1in54b {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd1in54c/graphics.rs
+++ b/src/epd1in54c/graphics.rs
@@ -37,7 +37,8 @@ impl DrawTarget for Display1in54c {
 
 impl OriginDimensions for Display1in54c {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -48,6 +49,13 @@ impl Display for Display1in54c {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd2in13_v2/graphics.rs
+++ b/src/epd2in13_v2/graphics.rs
@@ -40,7 +40,8 @@ impl DrawTarget for Display2in13 {
 
 impl OriginDimensions for Display2in13 {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -51,6 +52,13 @@ impl Display for Display2in13 {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd2in13bc/graphics.rs
+++ b/src/epd2in13bc/graphics.rs
@@ -39,7 +39,8 @@ impl DrawTarget for Display2in13bc {
 
 impl OriginDimensions for Display2in13bc {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -50,6 +51,13 @@ impl TriDisplay for Display2in13bc {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd2in7b/graphics.rs
+++ b/src/epd2in7b/graphics.rs
@@ -39,7 +39,8 @@ impl DrawTarget for Display2in7b {
 
 impl OriginDimensions for Display2in7b {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -50,6 +51,13 @@ impl Display for Display2in7b {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd2in9/graphics.rs
+++ b/src/epd2in9/graphics.rs
@@ -39,7 +39,8 @@ impl DrawTarget for Display2in9 {
 
 impl OriginDimensions for Display2in9 {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -50,6 +51,13 @@ impl Display for Display2in9 {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd2in9_v2/graphics.rs
+++ b/src/epd2in9_v2/graphics.rs
@@ -39,7 +39,8 @@ impl DrawTarget for Display2in9 {
 
 impl OriginDimensions for Display2in9 {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -50,6 +51,13 @@ impl Display for Display2in9 {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd2in9bc/graphics.rs
+++ b/src/epd2in9bc/graphics.rs
@@ -37,7 +37,8 @@ impl DrawTarget for Display2in9bc {
 
 impl OriginDimensions for Display2in9bc {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -48,6 +49,13 @@ impl Display for Display2in9bc {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd4in2/graphics.rs
+++ b/src/epd4in2/graphics.rs
@@ -38,7 +38,8 @@ impl DrawTarget for Display4in2 {
 
 impl OriginDimensions for Display4in2 {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -49,6 +50,13 @@ impl Display for Display4in2 {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd5in65f/graphics.rs
+++ b/src/epd5in65f/graphics.rs
@@ -39,7 +39,8 @@ impl DrawTarget for Display5in65f {
 
 impl OriginDimensions for Display5in65f {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -50,6 +51,13 @@ impl OctDisplay for Display5in65f {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd5in83b_v2/graphics.rs
+++ b/src/epd5in83b_v2/graphics.rs
@@ -43,7 +43,8 @@ impl DrawTarget for Display5in83 {
 
 impl OriginDimensions for Display5in83 {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -54,6 +55,13 @@ impl TriDisplay for Display5in83 {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd7in5/graphics.rs
+++ b/src/epd7in5/graphics.rs
@@ -39,7 +39,8 @@ impl DrawTarget for Display7in5 {
 
 impl OriginDimensions for Display7in5 {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -50,6 +51,13 @@ impl Display for Display7in5 {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd7in5_hd/graphics.rs
+++ b/src/epd7in5_hd/graphics.rs
@@ -39,7 +39,8 @@ impl DrawTarget for Display7in5 {
 
 impl OriginDimensions for Display7in5 {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -50,6 +51,13 @@ impl Display for Display7in5 {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/epd7in5_v2/graphics.rs
+++ b/src/epd7in5_v2/graphics.rs
@@ -39,7 +39,8 @@ impl DrawTarget for Display7in5 {
 
 impl OriginDimensions for Display7in5 {
     fn size(&self) -> Size {
-        Size::new(WIDTH, HEIGHT)
+        let (w, h) = self.dimensions();
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -50,6 +51,13 @@ impl Display for Display7in5 {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         &mut self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (WIDTH, HEIGHT),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (HEIGHT, WIDTH),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -61,6 +61,9 @@ pub trait Display: DrawTarget<Color = BinaryColor> {
     /// Returns a mutable buffer
     fn get_mut_buffer(&mut self) -> &mut [u8];
 
+    /// Get display dimensions, taking into account the current rotation of the display
+    fn dimensions(&self) -> (u32, u32);
+
     /// Sets the rotation of the display
     fn set_rotation(&mut self, rotation: DisplayRotation);
 
@@ -122,6 +125,9 @@ pub trait TriDisplay: DrawTarget<Color = TriColor> {
 
     /// Returns a mutable buffer
     fn get_mut_buffer(&mut self) -> &mut [u8];
+
+    /// Get display dimensions, taking into account the current rotation of the display
+    fn dimensions(&self) -> (u32, u32);
 
     /// Sets the rotation of the display
     fn set_rotation(&mut self, rotation: DisplayRotation);
@@ -242,6 +248,9 @@ pub trait OctDisplay: DrawTarget<Color = OctColor> {
     /// Returns a mutable buffer
     fn get_mut_buffer(&mut self) -> &mut [u8];
 
+    /// Get display dimensions, taking into account the current rotation of the display
+    fn dimensions(&self) -> (u32, u32);
+
     /// Sets the rotation of the display
     fn set_rotation(&mut self, rotation: DisplayRotation);
 
@@ -347,7 +356,9 @@ impl<'a> DrawTarget for VarDisplay<'a> {
 
 impl<'a> OriginDimensions for VarDisplay<'a> {
     fn size(&self) -> Size {
-        Size::new(self.width, self.height)
+        let (w, h) = self.dimensions();
+
+        Size::new(w.into(), h.into())
     }
 }
 
@@ -358,6 +369,13 @@ impl<'a> Display for VarDisplay<'a> {
 
     fn get_mut_buffer(&mut self) -> &mut [u8] {
         self.buffer
+    }
+
+    fn dimensions(&self) -> (u32, u32) {
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => (self.width, self.height),
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => (self.height, self.width),
+        }
     }
 
     fn set_rotation(&mut self, rotation: DisplayRotation) {


### PR DESCRIPTION
This PR fixes #104 where `embedded-graphics` text alignment features were not working because the `size()` method wasn't taking display rotation into account.