### PR TITLE
Clippy: Omit let-bindungs for unit values

### DIFF
--- a/src/epd1in54/mod.rs
+++ b/src/epd1in54/mod.rs
@@ -299,7 +299,7 @@ where
     DELAY: DelayMs<u8>,
 {
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     pub(crate) fn use_full_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd1in54_v2/mod.rs
+++ b/src/epd1in54_v2/mod.rs
@@ -274,7 +274,7 @@ where
     DELAY: DelayMs<u8>,
 {
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     pub(crate) fn use_full_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd1in54b/mod.rs
+++ b/src/epd1in54b/mod.rs
@@ -333,7 +333,7 @@ where
     }
 
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd1in54c/mod.rs
+++ b/src/epd1in54c/mod.rs
@@ -275,7 +275,7 @@ where
     }
 
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd2in13_v2/mod.rs
+++ b/src/epd2in13_v2/mod.rs
@@ -560,7 +560,7 @@ where
     }
 
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 }
 

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -356,7 +356,7 @@ where
     }
 
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd2in7b/mod.rs
+++ b/src/epd2in7b/mod.rs
@@ -357,7 +357,7 @@ where
     }
 
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     /// Refresh display for partial frame

--- a/src/epd2in9/mod.rs
+++ b/src/epd2in9/mod.rs
@@ -295,7 +295,7 @@ where
     DELAY: DelayMs<u8>,
 {
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn use_full_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd2in9bc/mod.rs
+++ b/src/epd2in9bc/mod.rs
@@ -359,7 +359,7 @@ where
     }
 
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -369,7 +369,7 @@ where
     }
 
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd5in65f/mod.rs
+++ b/src/epd5in65f/mod.rs
@@ -225,10 +225,10 @@ where
     }
 
     fn wait_busy_high(&mut self) {
-        let _ = self.interface.wait_until_idle(true);
+        self.interface.wait_until_idle(true);
     }
     fn wait_busy_low(&mut self) {
-        let _ = self.interface.wait_until_idle(false);
+        self.interface.wait_until_idle(false);
     }
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
         let w = self.width();

--- a/src/epd5in83b_v2/mod.rs
+++ b/src/epd5in83b_v2/mod.rs
@@ -314,7 +314,7 @@ where
     }
 
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd7in5/mod.rs
+++ b/src/epd7in5/mod.rs
@@ -255,7 +255,7 @@ where
     }
 
     fn wait_until_idle(&mut self) {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd7in5_v3/mod.rs
+++ b/src/epd7in5_v3/mod.rs
@@ -298,7 +298,7 @@ where
     }
 
     fn wait_until_idle_raw(&mut self) -> Result<(), SPI::Error> {
-        let _ = self.interface.wait_until_idle(IS_BUSY_LOW);
+        self.interface.wait_until_idle(IS_BUSY_LOW);
         Ok(())
     }
 


### PR DESCRIPTION
Clippy: Omit let-bindungs for unit values for `interface.wait_until_idle` calls