### PR TITLE
Add epd7in5b_v2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added support for positive and negatives modes of rendering in TriColor display in #92 (thanks to @akashihi)
 - Added Epd 5in83 V2 (B) support in #92 (thanks to @akashihi)
+- Added Epd 7in5 (B) V2 and V3 support
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ epd.update_and_display_frame( & mut spi, & display.buffer()) ?;
 
 | Device (with Link) | Colors | Flexible Display | Partial Refresh | Supported | Tested |
 | :---: | --- | :---: | :---: | :---: | :---: |
+| [7.5 Inch B/W/R V2/V3 (B)](https://www.waveshare.com/product/displays/e-paper/epaper-1/7.5inch-e-paper-b.htm) | Black, White, Red | ✕ | ✕ | ✔ | ✔ |
 | [7.5 Inch B/W HD (A)](https://www.waveshare.com/product/displays/e-paper/epaper-1/7.5inch-hd-e-paper-hat.htm) | Black, White | ✕ | ✕ | ✔ | ✔ |
 | [7.5 Inch B/W V2 (A)](https://www.waveshare.com/product/7.5inch-e-paper-hat.htm) [[1](#1-75-inch-bw-v2-a)] | Black, White | ✕ | ✕ | ✔ | ✔ |
 | [7.5 Inch B/W (A)](https://www.waveshare.com/product/7.5inch-e-paper-hat.htm) | Black, White | ✕ | ✕ | ✔ | ✔ |

--- a/src/color.rs
+++ b/src/color.rs
@@ -26,7 +26,7 @@ impl OutOfColorRangeParseError {
 }
 
 /// Only for the Black/White-Displays
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Color {
     /// Black color
     Black,
@@ -35,7 +35,7 @@ pub enum Color {
 }
 
 /// Only for the Black/White/Color-Displays
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum TriColor {
     /// Black color
     Black,
@@ -46,7 +46,7 @@ pub enum TriColor {
 }
 
 /// For the 5in65 7 Color Display
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum OctColor {
     /// Black Color
     Black = 0x00,

--- a/src/epd7in5b_v2/command.rs
+++ b/src/epd7in5b_v2/command.rs
@@ -1,0 +1,156 @@
+//! SPI Commands for the Waveshare 7.5"(B) V2 E-Ink Display
+
+use crate::traits;
+
+/// Epd7in5 commands
+///
+/// Should rarely (never?) be needed directly.
+///
+/// For more infos about the addresses and what they are doing look into the PDFs.
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub(crate) enum Command {
+    /// Set Resolution, LUT selection, BWR pixels, gate scan direction, source shift
+    /// direction, booster switch, soft reset.
+    PanelSetting = 0x00,
+
+    /// Selecting internal and external power
+    PowerSetting = 0x01,
+
+    /// After the Power Off command, the driver will power off following the Power Off
+    /// Sequence; BUSY signal will become "0". This command will turn off charge pump,
+    /// T-con, source driver, gate driver, VCOM, and temperature sensor, but register
+    /// data will be kept until VDD becomes OFF. Source Driver output and Vcom will remain
+    /// as previous condition, which may have 2 conditions: 0V or floating.
+    PowerOff = 0x02,
+
+    /// Setting Power OFF sequence
+    PowerOffSequenceSetting = 0x03,
+
+    /// Turning On the Power
+    ///
+    /// After the Power ON command, the driver will power on following the Power ON
+    /// sequence. Once complete, the BUSY signal will become "1".
+    PowerOn = 0x04,
+
+    /// Starting data transmission
+    BoosterSoftStart = 0x06,
+
+    /// This command makes the chip enter the deep-sleep mode to save power.
+    ///
+    /// The deep sleep mode would return to stand-by by hardware reset.
+    ///
+    /// The only one parameter is a check code, the command would be excuted if check code = 0xA5.
+    DeepSleep = 0x07,
+
+    /// This command starts transmitting data and write them into SRAM. To complete data
+    /// transmission, command DSP (Data Stop) must be issued. Then the chip will start to
+    /// send data/VCOM for panel.
+    ///
+    /// BLACK/WHITE or OLD_DATA
+    DataStartTransmission1 = 0x10,
+
+    /// To stop data transmission, this command must be issued to check the `data_flag`.
+    ///
+    /// After this command, BUSY signal will become "0" until the display update is
+    /// finished.
+    DataStop = 0x11,
+
+    /// After this command is issued, driver will refresh display (data/VCOM) according to
+    /// SRAM data and LUT.
+    ///
+    /// After Display Refresh command, BUSY signal will become "0" until the display
+    /// update is finished.
+    DisplayRefresh = 0x12,
+
+    /// RED or NEW_DATA
+    DataStartTransmission2 = 0x13,
+
+    /// Dual SPI - what for?
+    DualSpi = 0x15,
+
+    /// This command builds the VCOM Look-Up Table (LUTC).
+    LutC = 0x20,
+    /// This command builds the Black Look-Up Table (LUTB).
+    LutWW = 0x21,
+    /// This command builds the White Look-Up Table (LUTW).
+    LutBW = 0x22,
+    /// This command builds the Gray1 Look-Up Table (LUTG1).
+    LutWB = 0x23,
+    /// This command builds the Gray2 Look-Up Table (LUTG2).
+    LutBB = 0x24,
+    /// This command builds the Red0 Look-Up Table (LUTR0).
+    LutBD = 0x25,
+
+    /// LUT Option
+    LutOpt = 0x2A,
+    /// KW LUT Option
+    KWLutOpt = 0x2B,
+
+    /// The command controls the PLL clock frequency.
+    PllControl = 0x30,
+
+    /// This command reads the temperature sensed by the temperature sensor.
+    TemperatureSensor = 0x40,
+    /// This command selects the Internal or External temperature sensor.
+    TemperatureCalibration = 0x41,
+    /// This command could write data to the external temperature sensor.
+    TemperatureSensorWrite = 0x42,
+    /// This command could read data from the external temperature sensor.
+    TemperatureSensorRead = 0x43,
+
+    /// This command indicates the interval of Vcom and data output. When setting the
+    /// vertical back porch, the total blanking will be kept (20 Hsync).
+    VcomAndDataIntervalSetting = 0x50,
+    /// This command indicates the input power condition. Host can read this flag to learn
+    /// the battery condition.
+    LowPowerDetection = 0x51,
+
+    /// This command defines non-overlap period of Gate and Source.
+    TconSetting = 0x60,
+    /// This command defines alternative resolution and this setting is of higher priority
+    /// than the RES\[1:0\] in R00H (PSR).
+    TconResolution = 0x61,
+    /// This command defines MCU host direct access external memory mode.
+    SpiFlashControl = 0x65,
+
+    /// The LUT_REV / Chip Revision is read from OTP address = 25001 and 25000.
+    Revision = 0x70,
+    /// This command reads the IC status.
+    GetStatus = 0x71,
+
+    /// This command implements related VCOM sensing setting.
+    AutoMeasurementVcom = 0x80,
+    /// This command gets the VCOM value.
+    ReadVcomValue = 0x81,
+    /// This command sets `VCOM_DC` value.
+    VcmDcSetting = 0x82,
+    // /// This is in all the Waveshare controllers for Epd7in5, but it's not documented
+    // /// anywhere in the datasheet `¯\_(ツ)_/¯`
+    // FlashMode = 0xE5,
+    /// Sets window size for the partial update
+    PartialWindow = 0x90,
+    /// Sets chip into partial update mode
+    PartialIn = 0x91,
+    /// Quits partial update mode
+    PartialOut = 0x92,
+}
+
+impl traits::Command for Command {
+    /// Returns the address of the command
+    fn address(self) -> u8 {
+        self as u8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::Command as CommandTrait;
+
+    #[test]
+    fn command_addr() {
+        assert_eq!(Command::PanelSetting.address(), 0x00);
+        assert_eq!(Command::DisplayRefresh.address(), 0x12);
+    }
+}

--- a/src/epd7in5b_v2/command.rs
+++ b/src/epd7in5b_v2/command.rs
@@ -1,4 +1,4 @@
-//! SPI Commands for the Waveshare 7.5"(B) V2 E-Ink Display
+//! SPI Commands for the Waveshare 7.5"(B) V2 and V3 -Ink Display
 
 use crate::traits;
 

--- a/src/epd7in5b_v2/graphics.rs
+++ b/src/epd7in5b_v2/graphics.rs
@@ -1,0 +1,131 @@
+use crate::color::TriColor;
+use crate::epd7in5b_v2::{DEFAULT_BACKGROUND_COLOR, HEIGHT, NUM_DISPLAY_BYTES, WIDTH};
+use crate::graphics::{DisplayRotation, TriDisplay};
+use embedded_graphics_core::prelude::*;
+
+/// Full size buffer for use with the 7in5 EPD
+///
+/// Can also be manually constructed:
+/// `buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); 2 * NUM_DISPLAY_BYTES]`
+pub struct Display7in5 {
+    buffer: [u8; 2 * NUM_DISPLAY_BYTES],
+    rotation: DisplayRotation,
+}
+
+impl Default for Display7in5 {
+    // inline is necessary here to allow heap allocation via Box on stack limited programs
+    #[inline(always)]
+    fn default() -> Self {
+        Display7in5 {
+            // This way of initializing doesn't work for bicolor buffer
+            buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); 2*NUM_DISPLAY_BYTES],
+            rotation: DisplayRotation::default(),
+        }
+    }
+}
+
+impl Display7in5 {
+    /// Please call me after creating a default Display7in5 for bicolor display, otherwise
+    /// the default color won't be correct
+    pub fn init(&mut self) {
+        match DEFAULT_BACKGROUND_COLOR {
+            // white and chromatic are both 1
+            TriColor::White => self.buffer[NUM_DISPLAY_BYTES..].fill(0x00),
+            TriColor::Black => {},
+            TriColor::Chromatic => self.buffer[NUM_DISPLAY_BYTES..].fill(0xFF),
+        }
+    }
+}
+
+impl DrawTarget for Display7in5 {
+    type Color = TriColor;
+    type Error = core::convert::Infallible;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for pixel in pixels {
+            self.draw_helper_tri(
+                WIDTH,
+                HEIGHT,
+                pixel,
+                crate::graphics::DisplayColorRendering::Negative,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl OriginDimensions for Display7in5 {
+    fn size(&self) -> Size {
+        Size::new(WIDTH, HEIGHT)
+    }
+}
+
+impl TriDisplay for Display7in5 {
+    fn buffer(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    fn get_mut_buffer(&mut self) -> &mut [u8] {
+        &mut self.buffer
+    }
+
+    fn set_rotation(&mut self, rotation: DisplayRotation) {
+        self.rotation = rotation;
+    }
+
+    fn rotation(&self) -> DisplayRotation {
+        self.rotation
+    }
+
+    fn chromatic_offset(&self) -> usize {
+        NUM_DISPLAY_BYTES
+    }
+
+    fn bw_buffer(&self) -> &[u8] {
+        &self.buffer[0..self.chromatic_offset()]
+    }
+
+    fn chromatic_buffer(&self) -> &[u8] {
+        &self.buffer[self.chromatic_offset()..]
+    }
+
+    fn clear_buffer(&mut self, background_color: TriColor) {
+        let offset = self.chromatic_offset();
+
+        for (i, elem) in self.get_mut_buffer().iter_mut().enumerate() {
+            if i < offset {
+                *elem = background_color.get_byte_value();
+            }
+            // for V3, white in the BW buffer is 255. But in the chromatic buffer 255 is red.
+            // This means that the chromatic buffer needs to be inverted when clearing
+            else {
+                *elem = background_color.get_byte_value() ^ 0xFF;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::epd7in5_v3;
+
+    // test buffer length
+    #[test]
+    fn graphics_size() {
+        let display = Display7in5::default();
+        assert_eq!(display.buffer().len(), 96000);
+    }
+
+    // test default background color on all bytes
+    #[test]
+    fn graphics_default() {
+        let display = Display7in5::default();
+        for &byte in display.buffer() {
+            assert_eq!(byte, epd7in5_v3::DEFAULT_BACKGROUND_COLOR.get_byte_value());
+        }
+    }
+}

--- a/src/epd7in5b_v2/graphics.rs
+++ b/src/epd7in5b_v2/graphics.rs
@@ -18,7 +18,7 @@ impl Default for Display7in5 {
     fn default() -> Self {
         Display7in5 {
             // This way of initializing doesn't work for bicolor buffer
-            buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); 2*NUM_DISPLAY_BYTES],
+            buffer: [DEFAULT_BACKGROUND_COLOR.get_byte_value(); 2 * NUM_DISPLAY_BYTES],
             rotation: DisplayRotation::default(),
         }
     }
@@ -31,7 +31,7 @@ impl Display7in5 {
         match DEFAULT_BACKGROUND_COLOR {
             // white and chromatic are both 1
             TriColor::White => self.buffer[NUM_DISPLAY_BYTES..].fill(0x00),
-            TriColor::Black => {},
+            TriColor::Black => {}
             TriColor::Chromatic => self.buffer[NUM_DISPLAY_BYTES..].fill(0xFF),
         }
     }

--- a/src/epd7in5b_v2/mod.rs
+++ b/src/epd7in5b_v2/mod.rs
@@ -19,8 +19,6 @@ use crate::color::TriColor;
 use crate::interface::DisplayInterface;
 use crate::traits::{InternalWiAdditions, RefreshLut, WaveshareDisplay};
 
-
-
 pub(crate) mod command;
 use self::command::Command;
 
@@ -73,7 +71,8 @@ where
         // C driver adds a static 100ms delay here
         self.wait_until_idle(spi, delay)?;
         // Done, but this is also the default
-        self.cmd_with_data(spi, Command::PanelSetting, &[0x0F])?; // 0x1F = B/W mode ? doesnt seem to work
+        // 0x1F = B/W mode ? doesnt seem to work
+        self.cmd_with_data(spi, Command::PanelSetting, &[0x0F])?;
         // Not done in C driver, this is the default
         //self.cmd_with_data(spi, Command::PllControl, &[0x06])?;
         self.cmd_with_data(spi, Command::TconResolution, &[0x03, 0x20, 0x01, 0xE0])?;
@@ -146,8 +145,16 @@ where
     ) -> Result<(), SPI::Error> {
         self.wait_until_idle(spi, delay)?;
         // (B) version sends one buffer for black and one for red
-        self.cmd_with_data(spi, Command::DataStartTransmission1, &buffer[.. NUM_DISPLAY_BYTES])?;
-        self.cmd_with_data(spi, Command::DataStartTransmission2, &buffer[NUM_DISPLAY_BYTES..])?;
+        self.cmd_with_data(
+            spi,
+            Command::DataStartTransmission1,
+            &buffer[..NUM_DISPLAY_BYTES],
+        )?;
+        self.cmd_with_data(
+            spi,
+            Command::DataStartTransmission2,
+            &buffer[NUM_DISPLAY_BYTES..],
+        )?;
         Ok(())
     }
 
@@ -260,7 +267,9 @@ where
         let pt_scan = 0x01; // Gates scan both inside and outside of the partial window. (default)
 
         self.command(spi, Command::PartialIn)?;
-        self.cmd_with_data(spi, Command::PartialWindow,
+        self.cmd_with_data(
+            spi,
+            Command::PartialWindow,
             &[
                 hrst_upper, hrst_lower, hred_upper, hred_lower, vrst_upper, vrst_lower, vred_upper,
                 vred_lower, pt_scan,

--- a/src/epd7in5b_v2/mod.rs
+++ b/src/epd7in5b_v2/mod.rs
@@ -1,0 +1,333 @@
+//! A simple Driver for the Waveshare 7.5" (B) E-Ink Display (V2) via SPI
+//!
+//! # References
+//!
+//! - [Datasheet](https://www.waveshare.com/wiki/7.5inch_e-Paper_HAT)
+//! - [Waveshare C driver](https://github.com/waveshare/e-Paper/blob/702def0/RaspberryPi%26JetsonNano/c/lib/e-Paper/EPD_7in5_V2.c)
+//! - [Waveshare Python driver](https://github.com/waveshare/e-Paper/blob/702def0/RaspberryPi%26JetsonNano/python/lib/waveshare_epd/epd7in5_V2.py)
+//!
+//! Important note for V2:
+//! Revision V2 has been released on 2019.11, the resolution is upgraded to 800×480, from 640×384 of V1.
+//! The hardware and interface of V2 are compatible with V1, however, the related software should be updated.
+
+use embedded_hal::{
+    blocking::{delay::*, spi::Write},
+    digital::v2::{InputPin, OutputPin},
+};
+
+use crate::color::TriColor;
+use crate::interface::DisplayInterface;
+use crate::traits::{InternalWiAdditions, RefreshLut, WaveshareDisplay};
+
+
+
+pub(crate) mod command;
+use self::command::Command;
+
+#[cfg(feature = "graphics")]
+mod graphics;
+#[cfg(feature = "graphics")]
+pub use self::graphics::Display7in5;
+
+/// Width of the display
+pub const WIDTH: u32 = 800;
+/// Height of the display
+pub const HEIGHT: u32 = 480;
+/// Default Background Color
+pub const DEFAULT_BACKGROUND_COLOR: TriColor = TriColor::White;
+
+const NUM_DISPLAY_BYTES: usize = WIDTH as usize * HEIGHT as usize / 8;
+const IS_BUSY_LOW: bool = true;
+
+/// Epd7in5 (V2) driver
+///
+pub struct Epd7in5<SPI, CS, BUSY, DC, RST, DELAY> {
+    /// Connection Interface
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    /// Background Color
+    color: TriColor,
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> InternalWiAdditions<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd7in5<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayMs<u8>,
+{
+    fn init(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        // Reset the device
+        // C driver does 200/2 original rust driver does 10/2
+        self.interface.reset(delay, 200, 2);
+
+        // V2 procedure as described here:
+        // https://github.com/waveshare/e-Paper/blob/master/RaspberryPi%26JetsonNano/python/lib/waveshare_epd/epd7in5bc_V2.py
+        // and as per specs:
+        // https://www.waveshare.com/w/upload/6/60/7.5inch_e-Paper_V2_Specification.pdf
+
+        self.cmd_with_data(spi, Command::PowerSetting, &[0x07, 0x07, 0x3F, 0x3F])?;
+        self.command(spi, Command::PowerOn)?;
+        // C driver adds a static 100ms delay here
+        self.wait_until_idle(spi, delay)?;
+        // Done, but this is also the default
+        self.cmd_with_data(spi, Command::PanelSetting, &[0x0F])?; // 0x1F = B/W mode ? doesnt seem to work
+        // Not done in C driver, this is the default
+        //self.cmd_with_data(spi, Command::PllControl, &[0x06])?;
+        self.cmd_with_data(spi, Command::TconResolution, &[0x03, 0x20, 0x01, 0xE0])?;
+        // Documentation removed in v3 but done in v2 and works in v3
+        self.cmd_with_data(spi, Command::DualSpi, &[0x00])?;
+        //                    0x10 in BW mode  (Work ?) V
+        //                    0x12 in BW mode to disable new/old thing
+        //                    0x01 -> Black border
+        //                    0x11 -> White norder
+        //                    0x21 -> Red border
+        //                    0x31 -> don't touch border
+        //                    the second nibble can change polarity (may be easier for default
+        //                    display initialization)                   V
+        self.cmd_with_data(spi, Command::VcomAndDataIntervalSetting, &[0x11, 0x07])?;
+        // This is the default
+        self.cmd_with_data(spi, Command::TconSetting, &[0x22])?;
+        self.cmd_with_data(spi, Command::SpiFlashControl, &[0x00, 0x00, 0x00, 0x00])?;
+        // Not in C driver
+        self.wait_until_idle(spi, delay)?;
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> WaveshareDisplay<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd7in5<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayMs<u8>,
+{
+    type DisplayColor = TriColor;
+    fn new(
+        spi: &mut SPI,
+        cs: CS,
+        busy: BUSY,
+        dc: DC,
+        rst: RST,
+        delay: &mut DELAY,
+    ) -> Result<Self, SPI::Error> {
+        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let color = DEFAULT_BACKGROUND_COLOR;
+
+        let mut epd = Epd7in5 { interface, color };
+
+        epd.init(spi, delay)?;
+
+        Ok(epd)
+    }
+
+    fn wake_up(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.init(spi, delay)
+    }
+
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
+        self.command(spi, Command::PowerOff)?;
+        self.wait_until_idle(spi, delay)?;
+        self.cmd_with_data(spi, Command::DeepSleep, &[0xA5])?;
+        Ok(())
+    }
+
+    fn update_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
+        // (B) version sends one buffer for black and one for red
+        self.cmd_with_data(spi, Command::DataStartTransmission1, &buffer[.. NUM_DISPLAY_BYTES])?;
+        self.cmd_with_data(spi, Command::DataStartTransmission2, &buffer[NUM_DISPLAY_BYTES..])?;
+        Ok(())
+    }
+
+    fn update_partial_frame(
+        &mut self,
+        _spi: &mut SPI,
+        _buffer: &[u8],
+        _x: u32,
+        _y: u32,
+        _width: u32,
+        _height: u32,
+    ) -> Result<(), SPI::Error> {
+        unimplemented!()
+    }
+
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
+        self.command(spi, Command::DisplayRefresh)?;
+        Ok(())
+    }
+
+    fn update_and_display_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.update_frame(spi, buffer, delay)?;
+        self.command(spi, Command::DisplayRefresh)?;
+        Ok(())
+    }
+
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
+        self.send_resolution(spi)?;
+
+        self.command(spi, Command::DataStartTransmission1)?;
+        self.interface.data_x_times(spi, 0xFF, WIDTH * HEIGHT / 8)?;
+
+        self.command(spi, Command::DataStartTransmission2)?;
+        self.interface.data_x_times(spi, 0x00, WIDTH * HEIGHT / 8)?;
+
+        self.command(spi, Command::DisplayRefresh)?;
+
+        Ok(())
+    }
+
+    fn set_background_color(&mut self, color: Self::DisplayColor) {
+        self.color = color;
+    }
+
+    fn background_color(&self) -> &Self::DisplayColor {
+        &self.color
+    }
+
+    fn width(&self) -> u32 {
+        WIDTH
+    }
+
+    fn height(&self) -> u32 {
+        HEIGHT
+    }
+
+    fn set_lut(
+        &mut self,
+        _spi: &mut SPI,
+        _refresh_rate: Option<RefreshLut>,
+    ) -> Result<(), SPI::Error> {
+        unimplemented!();
+    }
+
+    fn is_busy(&self) -> bool {
+        self.interface.is_busy(IS_BUSY_LOW)
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> Epd7in5<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayMs<u8>,
+{
+    /// temporary replacement for missing delay in the trait to call wait_until_idle
+    pub fn update_partial_frame2(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
+        if buffer.len() as u32 != width / 8 * height {
+            //TODO panic or error
+        }
+
+        let hrst_upper = (x / 8) as u8 >> 5;
+        let hrst_lower = ((x / 8) << 3) as u8;
+        let hred_upper = ((x + width) / 8 - 1) as u8 >> 5;
+        let hred_lower = (((x + width) / 8 - 1) << 3) as u8 | 0b111;
+        let vrst_upper = (y >> 8) as u8;
+        let vrst_lower = y as u8;
+        let vred_upper = ((y + height - 1) >> 8) as u8;
+        let vred_lower = (y + height - 1) as u8;
+        let pt_scan = 0x01; // Gates scan both inside and outside of the partial window. (default)
+
+        self.command(spi, Command::PartialIn)?;
+        self.cmd_with_data(spi, Command::PartialWindow,
+            &[
+                hrst_upper, hrst_lower, hred_upper, hred_lower, vrst_upper, vrst_lower, vred_upper,
+                vred_lower, pt_scan,
+            ],
+        )?;
+        let half = buffer.len() / 2;
+        self.cmd_with_data(spi, Command::DataStartTransmission1, &buffer[..half])?;
+        self.cmd_with_data(spi, Command::DataStartTransmission2, &buffer[half..])?;
+
+        self.command(spi, Command::DisplayRefresh)?;
+        self.wait_until_idle(spi, delay)?;
+
+        self.command(spi, Command::PartialOut)?;
+        Ok(())
+    }
+
+    fn command(&mut self, spi: &mut SPI, command: Command) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, command)
+    }
+
+    fn send_data(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
+        self.interface.data(spi, data)
+    }
+
+    fn cmd_with_data(
+        &mut self,
+        spi: &mut SPI,
+        command: Command,
+        data: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd_with_data(spi, command, data)
+    }
+
+    /// wait
+    pub fn wait_until_idle(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        // C driver first sends the command
+        self.interface.cmd(spi, Command::GetStatus)?;
+        while self.interface.is_busy(IS_BUSY_LOW) {
+            self.interface.cmd(spi, Command::GetStatus)?;
+            // C driver doesn't wait here but we have to
+            // because be want to be able to give back control if we are in a RT thread
+            delay.delay_ms(10);
+        }
+        // C driver add 200ms here
+        Ok(())
+    }
+
+    fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        let w = self.width();
+        let h = self.height();
+
+        self.command(spi, Command::TconResolution)?;
+        self.send_data(spi, &[(w >> 8) as u8])?;
+        self.send_data(spi, &[w as u8])?;
+        self.send_data(spi, &[(h >> 8) as u8])?;
+        self.send_data(spi, &[h as u8])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epd_size() {
+        assert_eq!(WIDTH, 800);
+        assert_eq!(HEIGHT, 480);
+        assert_eq!(DEFAULT_BACKGROUND_COLOR, TriColor::White);
+    }
+}

--- a/src/epd7in5b_v2/mod.rs
+++ b/src/epd7in5b_v2/mod.rs
@@ -241,6 +241,7 @@ where
     DELAY: DelayMs<u8>,
 {
     /// temporary replacement for missing delay in the trait to call wait_until_idle
+    #[allow(clippy::too_many_arguments)]
     pub fn update_partial_frame2(
         &mut self,
         spi: &mut SPI,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub mod epd5in83b_v2;
 pub mod epd7in5;
 pub mod epd7in5_hd;
 pub mod epd7in5_v2;
+pub mod epd7in5b_v2;
 pub mod epd7in5_v3;
 
 pub(crate) mod type_a;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,8 @@ pub mod epd5in83b_v2;
 pub mod epd7in5;
 pub mod epd7in5_hd;
 pub mod epd7in5_v2;
-pub mod epd7in5b_v2;
 pub mod epd7in5_v3;
+pub mod epd7in5b_v2;
 
 pub(crate) mod type_a;
 


### PR DESCRIPTION
Support of 7.5" (b) v2 (3 colors with back, white, red)
It is based on  epd7in5_v2 which doesn't work (epd7in5_v3 neither)
It is also based on the arduino C driver and datasheet.
It works on my V3 but the C driver and the datasheet haven't changed between v2 and v3.