### PR TITLE
Make wait_for_idle work for everyone, with busy loop or sleep loop

### DIFF
--- a/examples/epd1in54_no_graphics.rs
+++ b/examples/epd1in54_no_graphics.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), std::io::Error> {
 
     // Setup of the needed pins is finished here
     // Now the "real" usage of the eink-waveshare-rs crate begins
-    let mut epd = Epd1in54::new(&mut spi, cs_pin, busy, dc, rst, &mut delay, 5)?;
+    let mut epd = Epd1in54::new(&mut spi, cs_pin, busy, dc, rst, &mut delay, Some(5))?;
 
     // Clear the full screen
     epd.clear_frame(&mut spi, &mut delay)?;

--- a/examples/epd1in54_no_graphics.rs
+++ b/examples/epd1in54_no_graphics.rs
@@ -58,19 +58,27 @@ fn main() -> Result<(), std::io::Error> {
 
     // Setup of the needed pins is finished here
     // Now the "real" usage of the eink-waveshare-rs crate begins
-    let mut epd = Epd1in54::new(&mut spi, cs_pin, busy, dc, rst, &mut delay)?;
+    let mut epd = Epd1in54::new(&mut spi, cs_pin, busy, dc, rst, &mut delay, 5)?;
 
     // Clear the full screen
     epd.clear_frame(&mut spi, &mut delay)?;
     epd.display_frame(&mut spi, &mut delay)?;
 
     // Speeddemo
-    epd.set_lut(&mut spi, Some(RefreshLut::Quick))?;
+    epd.set_lut(&mut spi, &mut delay, Some(RefreshLut::Quick))?;
     let small_buffer = [Color::Black.get_byte_value(); 32]; //16x16
     let number_of_runs = 1;
     for i in 0..number_of_runs {
         let offset = i * 8 % 150;
-        epd.update_partial_frame(&mut spi, &small_buffer, 25 + offset, 25 + offset, 16, 16)?;
+        epd.update_partial_frame(
+            &mut spi,
+            &mut delay,
+            &small_buffer,
+            25 + offset,
+            25 + offset,
+            16,
+            16,
+        )?;
         epd.display_frame(&mut spi, &mut delay)?;
     }
 
@@ -80,13 +88,13 @@ fn main() -> Result<(), std::io::Error> {
 
     // Draw some squares
     let small_buffer = [Color::Black.get_byte_value(); 3200]; //160x160
-    epd.update_partial_frame(&mut spi, &small_buffer, 20, 20, 160, 160)?;
+    epd.update_partial_frame(&mut spi, &mut delay, &small_buffer, 20, 20, 160, 160)?;
 
     let small_buffer = [Color::White.get_byte_value(); 800]; //80x80
-    epd.update_partial_frame(&mut spi, &small_buffer, 60, 60, 80, 80)?;
+    epd.update_partial_frame(&mut spi, &mut delay, &small_buffer, 60, 60, 80, 80)?;
 
     let small_buffer = [Color::Black.get_byte_value(); 8]; //8x8
-    epd.update_partial_frame(&mut spi, &small_buffer, 96, 96, 8, 8)?;
+    epd.update_partial_frame(&mut spi, &mut delay, &small_buffer, 96, 96, 8, 8)?;
 
     // Display updated frame
     epd.display_frame(&mut spi, &mut delay)?;

--- a/examples/epd2in13_v2.rs
+++ b/examples/epd2in13_v2.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut delay = Delay {};
 
     let mut epd2in13 =
-        Epd2in13::new(&mut spi, cs, busy, dc, rst, &mut delay).expect("eink initalize error");
+        Epd2in13::new(&mut spi, cs, busy, dc, rst, &mut delay, 5).expect("eink initalize error");
 
     //println!("Test all the rotations");
     let mut display = Display2in13::default();

--- a/examples/epd2in13_v2.rs
+++ b/examples/epd2in13_v2.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut delay = Delay {};
 
     let mut epd2in13 =
-        Epd2in13::new(&mut spi, cs, busy, dc, rst, &mut delay, 5).expect("eink initalize error");
+        Epd2in13::new(&mut spi, cs, busy, dc, rst, &mut delay, None).expect("eink initalize error");
 
     //println!("Test all the rotations");
     let mut display = Display2in13::default();

--- a/examples/epd2in13bc.rs
+++ b/examples/epd2in13bc.rs
@@ -71,8 +71,8 @@ fn main() -> Result<(), std::io::Error> {
 
     let mut delay = Delay {};
 
-    let mut epd2in13 =
-        Epd2in13bc::new(&mut spi, cs, busy, dc, rst, &mut delay, 5).expect("eink initalize error");
+    let mut epd2in13 = Epd2in13bc::new(&mut spi, cs, busy, dc, rst, &mut delay, None)
+        .expect("eink initalize error");
 
     println!("Test all the rotations");
     let mut display = Display2in13bc::default();

--- a/examples/epd2in13bc.rs
+++ b/examples/epd2in13bc.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut delay = Delay {};
 
     let mut epd2in13 =
-        Epd2in13bc::new(&mut spi, cs, busy, dc, rst, &mut delay).expect("eink initalize error");
+        Epd2in13bc::new(&mut spi, cs, busy, dc, rst, &mut delay, 5).expect("eink initalize error");
 
     println!("Test all the rotations");
     let mut display = Display2in13bc::default();
@@ -137,7 +137,12 @@ fn main() -> Result<(), std::io::Error> {
 
     // we used three colors, so we need to update both bw-buffer and chromatic-buffer
 
-    epd2in13.update_color_frame(&mut spi, display.bw_buffer(), display.chromatic_buffer())?;
+    epd2in13.update_color_frame(
+        &mut spi,
+        &mut delay,
+        display.bw_buffer(),
+        display.chromatic_buffer(),
+    )?;
     epd2in13
         .display_frame(&mut spi, &mut delay)
         .expect("display frame new graphics");
@@ -147,7 +152,12 @@ fn main() -> Result<(), std::io::Error> {
 
     // clear both bw buffer and chromatic buffer
     display.clear(TriColor::White).ok();
-    epd2in13.update_color_frame(&mut spi, display.bw_buffer(), display.chromatic_buffer())?;
+    epd2in13.update_color_frame(
+        &mut spi,
+        &mut delay,
+        display.bw_buffer(),
+        display.chromatic_buffer(),
+    )?;
     epd2in13.display_frame(&mut spi, &mut delay)?;
 
     println!("Finished tests - going to sleep");

--- a/examples/epd4in2.rs
+++ b/examples/epd4in2.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut delay = Delay {};
 
     let mut epd4in2 =
-        Epd4in2::new(&mut spi, cs, busy, dc, rst, &mut delay).expect("eink initalize error");
+        Epd4in2::new(&mut spi, cs, busy, dc, rst, &mut delay, 5).expect("eink initalize error");
 
     println!("Test all the rotations");
     let mut display = Display4in2::default();
@@ -127,7 +127,9 @@ fn main() -> Result<(), std::io::Error> {
 
     // a moving `Hello World!`
     let limit = 10;
-    epd4in2.set_lut(&mut spi, Some(RefreshLut::Quick)).unwrap();
+    epd4in2
+        .set_lut(&mut spi, &mut delay, Some(RefreshLut::Quick))
+        .unwrap();
     epd4in2.clear_frame(&mut spi, &mut delay).unwrap();
     for i in 0..limit {
         //println!("Moving Hello World. Loop {} from {}", (i + 1), limit);

--- a/examples/epd4in2.rs
+++ b/examples/epd4in2.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut delay = Delay {};
 
     let mut epd4in2 =
-        Epd4in2::new(&mut spi, cs, busy, dc, rst, &mut delay, 5).expect("eink initalize error");
+        Epd4in2::new(&mut spi, cs, busy, dc, rst, &mut delay, None).expect("eink initalize error");
 
     println!("Test all the rotations");
     let mut display = Display4in2::default();

--- a/examples/epd4in2_variable_size.rs
+++ b/examples/epd4in2_variable_size.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut delay = Delay {};
 
     let mut epd4in2 =
-        Epd4in2::new(&mut spi, cs, busy, dc, rst, &mut delay).expect("eink initalize error");
+        Epd4in2::new(&mut spi, cs, busy, dc, rst, &mut delay, 5).expect("eink initalize error");
 
     println!("Test all the rotations");
 
@@ -84,7 +84,7 @@ fn main() -> Result<(), std::io::Error> {
     draw_text(&mut display, "Rotate 270!", 5, 50);
 
     epd4in2
-        .update_partial_frame(&mut spi, display.buffer(), x, y, width, height)
+        .update_partial_frame(&mut spi, &mut delay, display.buffer(), x, y, width, height)
         .unwrap();
     epd4in2
         .display_frame(&mut spi, &mut delay)
@@ -140,7 +140,7 @@ fn main() -> Result<(), std::io::Error> {
         draw_text(&mut display, "  Hello World! ", 5 + i * 12, 50);
 
         epd4in2
-            .update_partial_frame(&mut spi, display.buffer(), x, y, width, height)
+            .update_partial_frame(&mut spi, &mut delay, display.buffer(), x, y, width, height)
             .unwrap();
         epd4in2
             .display_frame(&mut spi, &mut delay)

--- a/examples/epd4in2_variable_size.rs
+++ b/examples/epd4in2_variable_size.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), std::io::Error> {
     let mut delay = Delay {};
 
     let mut epd4in2 =
-        Epd4in2::new(&mut spi, cs, busy, dc, rst, &mut delay, 5).expect("eink initalize error");
+        Epd4in2::new(&mut spi, cs, busy, dc, rst, &mut delay, None).expect("eink initalize error");
 
     println!("Test all the rotations");
 

--- a/src/epd1in54/mod.rs
+++ b/src/epd1in54/mod.rs
@@ -20,7 +20,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd1in54::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+//!let mut epd = Epd1in54::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!let mut display = Display1in54::default();
@@ -132,9 +132,9 @@ where
         self.interface
             .cmd_with_data(spi, Command::DataEntryModeSetting, &[0x03])?;
 
-        self.set_lut(spi, None)?;
+        self.set_lut(spi, delay, None)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 }
@@ -165,8 +165,9 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error> {
-        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
 
         let mut epd = Epd1in54 {
             interface,
@@ -183,8 +184,8 @@ where
         self.init(spi, delay)
     }
 
-    fn sleep(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         // 0x00 for Normal mode (Power on Reset), 0x01 for Deep Sleep Mode
         //TODO: is 0x00 needed here or would 0x01 be even more efficient?
         self.interface
@@ -196,10 +197,10 @@ where
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
-        self.use_full_frame(spi)?;
+        self.wait_until_idle(spi, delay)?;
+        self.use_full_frame(spi, delay)?;
         self.interface
             .cmd_with_data(spi, Command::WriteRam, buffer)?;
         Ok(())
@@ -209,23 +210,24 @@ where
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
         width: u32,
         height: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
-        self.set_ram_area(spi, x, y, x + width, y + height)?;
-        self.set_ram_counter(spi, x, y)?;
+        self.wait_until_idle(spi, delay)?;
+        self.set_ram_area(spi, delay, x, y, x + width, y + height)?;
+        self.set_ram_counter(spi, delay, x, y)?;
 
         self.interface
             .cmd_with_data(spi, Command::WriteRam, buffer)?;
         Ok(())
     }
 
-    fn display_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         // enable clock signal, enable cp, display pattern -> 0xC4 (tested with the arduino version)
         //TODO: test control_1 or control_2 with default value 0xFF (from the datasheet)
         self.interface
@@ -249,9 +251,9 @@ where
         Ok(())
     }
 
-    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
-        self.use_full_frame(spi)?;
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
+        self.use_full_frame(spi, delay)?;
 
         // clear the ram with the background color
         let color = self.background_color.get_byte_value();
@@ -273,19 +275,21 @@ where
     fn set_lut(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         if let Some(refresh_lut) = refresh_rate {
             self.refresh = refresh_lut;
         }
         match self.refresh {
-            RefreshLut::Full => self.set_lut_helper(spi, &LUT_FULL_UPDATE),
-            RefreshLut::Quick => self.set_lut_helper(spi, &LUT_PARTIAL_UPDATE),
+            RefreshLut::Full => self.set_lut_helper(spi, delay, &LUT_FULL_UPDATE),
+            RefreshLut::Quick => self.set_lut_helper(spi, delay, &LUT_PARTIAL_UPDATE),
         }
     }
 
-    fn is_busy(&self) -> bool {
-        self.interface.is_busy(IS_BUSY_LOW)
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
     }
 }
 
@@ -298,27 +302,28 @@ where
     RST: OutputPin,
     DELAY: DelayMs<u8>,
 {
-    fn wait_until_idle(&mut self) {
-        self.interface.wait_until_idle(IS_BUSY_LOW);
-    }
-
-    pub(crate) fn use_full_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+    pub(crate) fn use_full_frame(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
         // choose full frame/ram
-        self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
+        self.set_ram_area(spi, delay, 0, 0, WIDTH - 1, HEIGHT - 1)?;
 
         // start from the beginning
-        self.set_ram_counter(spi, 0, 0)
+        self.set_ram_counter(spi, delay, 0, 0)
     }
 
     pub(crate) fn set_ram_area(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         start_x: u32,
         start_y: u32,
         end_x: u32,
         end_y: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         assert!(start_x < end_x);
         assert!(start_y < end_y);
 
@@ -347,10 +352,11 @@ where
     pub(crate) fn set_ram_counter(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         x: u32,
         y: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         // x is positioned in bytes, so the last 3 bits which show the position inside a byte in the ram
         // aren't relevant
         self.interface
@@ -365,8 +371,13 @@ where
         Ok(())
     }
 
-    fn set_lut_helper(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn set_lut_helper(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+        buffer: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         assert!(buffer.len() == 30);
 
         self.interface

--- a/src/epd1in54/mod.rs
+++ b/src/epd1in54/mod.rs
@@ -20,7 +20,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd1in54::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
+//!let mut epd = Epd1in54::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!let mut display = Display1in54::default();
@@ -165,7 +165,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
 

--- a/src/epd1in54_v2/mod.rs
+++ b/src/epd1in54_v2/mod.rs
@@ -51,9 +51,9 @@ where
 {
     fn init(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         self.interface.reset(delay, 10, 10);
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.interface.cmd(spi, Command::SwReset)?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         // 3 Databytes:
         // A[7:0]
@@ -69,7 +69,7 @@ where
         self.interface
             .cmd_with_data(spi, Command::DataEntryModeSetting, &[0x3])?;
 
-        self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
+        self.set_ram_area(spi, delay, 0, 0, WIDTH - 1, HEIGHT - 1)?;
 
         self.interface
             .cmd_with_data(spi, Command::BorderWaveformControl, &[0x1])?;
@@ -83,9 +83,9 @@ where
         self.interface
             .cmd_with_data(spi, Command::TemperatureSensorControl, &[0xB1, 0x20])?;
 
-        self.set_ram_counter(spi, 0, 0)?;
+        self.set_ram_counter(spi, delay, 0, 0)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 }
@@ -116,8 +116,9 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error> {
-        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
 
         let mut epd = Epd1in54 {
             interface,
@@ -134,8 +135,8 @@ where
         self.init(spi, delay)
     }
 
-    fn sleep(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         // 0x00 for Normal mode (Power on Reset), 0x01 for Deep Sleep Mode
         //TODO: is 0x00 needed here or would 0x01 be even more efficient?
         self.interface
@@ -147,10 +148,10 @@ where
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
-        self.use_full_frame(spi)?;
+        self.wait_until_idle(spi, delay)?;
+        self.use_full_frame(spi, delay)?;
         self.interface
             .cmd_with_data(spi, Command::WriteRam, buffer)?;
         Ok(())
@@ -160,23 +161,24 @@ where
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
         width: u32,
         height: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
-        self.set_ram_area(spi, x, y, x + width, y + height)?;
-        self.set_ram_counter(spi, x, y)?;
+        self.wait_until_idle(spi, delay)?;
+        self.set_ram_area(spi, delay, x, y, x + width, y + height)?;
+        self.set_ram_counter(spi, delay, x, y)?;
 
         self.interface
             .cmd_with_data(spi, Command::WriteRam, buffer)?;
         Ok(())
     }
 
-    fn display_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         if self.refresh == RefreshLut::Full {
             self.interface
                 .cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xC7])?;
@@ -203,9 +205,9 @@ where
         Ok(())
     }
 
-    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
-        self.use_full_frame(spi)?;
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
+        self.use_full_frame(spi, delay)?;
 
         // clear the ram with the background color
         let color = self.background_color.get_byte_value();
@@ -230,14 +232,15 @@ where
     fn set_lut(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         if let Some(refresh_lut) = refresh_rate {
             self.refresh = refresh_lut;
         }
         match self.refresh {
-            RefreshLut::Full => self.set_lut_helper(spi, &LUT_FULL_UPDATE),
-            RefreshLut::Quick => self.set_lut_helper(spi, &LUT_PARTIAL_UPDATE),
+            RefreshLut::Full => self.set_lut_helper(spi, delay, &LUT_FULL_UPDATE),
+            RefreshLut::Quick => self.set_lut_helper(spi, delay, &LUT_PARTIAL_UPDATE),
         }?;
 
         // Additional configuration required only for partial updates
@@ -259,8 +262,9 @@ where
         Ok(())
     }
 
-    fn is_busy(&self) -> bool {
-        self.interface.is_busy(IS_BUSY_LOW)
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
     }
 }
 
@@ -273,27 +277,28 @@ where
     RST: OutputPin,
     DELAY: DelayMs<u8>,
 {
-    fn wait_until_idle(&mut self) {
-        self.interface.wait_until_idle(IS_BUSY_LOW);
-    }
-
-    pub(crate) fn use_full_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+    pub(crate) fn use_full_frame(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
         // choose full frame/ram
-        self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
+        self.set_ram_area(spi, delay, 0, 0, WIDTH - 1, HEIGHT - 1)?;
 
         // start from the beginning
-        self.set_ram_counter(spi, 0, 0)
+        self.set_ram_counter(spi, delay, 0, 0)
     }
 
     pub(crate) fn set_ram_area(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         start_x: u32,
         start_y: u32,
         end_x: u32,
         end_y: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         assert!(start_x < end_x);
         assert!(start_y < end_y);
 
@@ -322,10 +327,11 @@ where
     pub(crate) fn set_ram_counter(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         x: u32,
         y: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         // x is positioned in bytes, so the last 3 bits which show the position inside a byte in the ram
         // aren't relevant
         self.interface
@@ -340,8 +346,13 @@ where
         Ok(())
     }
 
-    fn set_lut_helper(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn set_lut_helper(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+        buffer: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         assert!(buffer.len() == 159);
 
         self.interface
@@ -350,7 +361,7 @@ where
         self.interface
             .cmd_with_data(spi, Command::WriteLutRegisterEnd, &[buffer[153]])?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         self.interface
             .cmd_with_data(spi, Command::GateDrivingVoltage, &[buffer[154]])?;

--- a/src/epd1in54_v2/mod.rs
+++ b/src/epd1in54_v2/mod.rs
@@ -116,7 +116,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
 

--- a/src/epd1in54b/mod.rs
+++ b/src/epd1in54b/mod.rs
@@ -63,7 +63,7 @@ where
         // power on
         self.command(spi, Command::PowerOn)?;
         delay.delay_ms(5);
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         // set the panel settings
         self.cmd_with_data(spi, Command::PanelSetting, &[0xCF])?;
@@ -78,9 +78,9 @@ where
 
         self.cmd_with_data(spi, Command::VcmDcSetting, &[0x0E])?;
 
-        self.set_lut(spi, None)?;
+        self.set_lut(spi, delay, None)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         Ok(())
     }
@@ -99,15 +99,21 @@ where
     fn update_color_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         black: &[u8],
         chromatic: &[u8],
     ) -> Result<(), SPI::Error> {
-        self.update_achromatic_frame(spi, black)?;
-        self.update_chromatic_frame(spi, chromatic)
+        self.update_achromatic_frame(spi, delay, black)?;
+        self.update_chromatic_frame(spi, delay, chromatic)
     }
 
-    fn update_achromatic_frame(&mut self, spi: &mut SPI, black: &[u8]) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn update_achromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+        black: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         self.send_resolution(spi)?;
 
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
@@ -122,6 +128,7 @@ where
     fn update_chromatic_frame(
         &mut self,
         spi: &mut SPI,
+        _delay: &mut DELAY,
         chromatic: &[u8],
     ) -> Result<(), SPI::Error> {
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
@@ -148,8 +155,9 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error> {
-        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;
 
         let mut epd = Epd1in54b { interface, color };
@@ -159,8 +167,8 @@ where
         Ok(epd)
     }
 
-    fn sleep(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         self.interface
             .cmd_with_data(spi, Command::VcomAndDataIntervalSetting, &[0x17])?; //border floating
 
@@ -170,7 +178,7 @@ where
         self.interface
             .cmd_with_data(spi, Command::PowerSetting, &[0x02, 0x00, 0x00, 0x00])?; //VG&VS to 0V fast
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         //NOTE: The example code has a 1s delay here
 
@@ -203,9 +211,9 @@ where
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.send_resolution(spi)?;
 
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
@@ -233,6 +241,7 @@ where
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
@@ -242,8 +251,8 @@ where
         unimplemented!()
     }
 
-    fn display_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         self.command(spi, Command::DisplayRefresh)?;
         Ok(())
     }
@@ -259,8 +268,8 @@ where
         Ok(())
     }
 
-    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         self.send_resolution(spi)?;
 
         let color = DEFAULT_BACKGROUND_COLOR.get_byte_value();
@@ -282,6 +291,7 @@ where
     fn set_lut(
         &mut self,
         spi: &mut SPI,
+        _delay: &mut DELAY,
         _refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         self.interface
@@ -302,8 +312,9 @@ where
         Ok(())
     }
 
-    fn is_busy(&self) -> bool {
-        self.interface.is_busy(IS_BUSY_LOW)
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
     }
 }
 
@@ -331,10 +342,6 @@ where
         data: &[u8],
     ) -> Result<(), SPI::Error> {
         self.interface.cmd_with_data(spi, command, data)
-    }
-
-    fn wait_until_idle(&mut self) {
-        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd1in54b/mod.rs
+++ b/src/epd1in54b/mod.rs
@@ -155,7 +155,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;

--- a/src/epd1in54c/mod.rs
+++ b/src/epd1in54c/mod.rs
@@ -59,7 +59,7 @@ where
         // power on
         self.command(spi, Command::PowerOn)?;
         delay.delay_ms(5);
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         // set the panel settings
         self.cmd_with_data(spi, Command::PanelSetting, &[0x0f, 0x0d])?;
@@ -86,15 +86,21 @@ where
     fn update_color_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         black: &[u8],
         chromatic: &[u8],
     ) -> Result<(), SPI::Error> {
-        self.update_achromatic_frame(spi, black)?;
-        self.update_chromatic_frame(spi, chromatic)
+        self.update_achromatic_frame(spi, delay, black)?;
+        self.update_chromatic_frame(spi, delay, chromatic)
     }
 
-    fn update_achromatic_frame(&mut self, spi: &mut SPI, black: &[u8]) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn update_achromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+        black: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         self.cmd_with_data(spi, Command::DataStartTransmission1, black)?;
 
         Ok(())
@@ -103,9 +109,10 @@ where
     fn update_chromatic_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         chromatic: &[u8],
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.cmd_with_data(spi, Command::DataStartTransmission2, chromatic)?;
 
         Ok(())
@@ -130,8 +137,9 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error> {
-        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;
 
         let mut epd = Epd1in54c { interface, color };
@@ -141,11 +149,11 @@ where
         Ok(epd)
     }
 
-    fn sleep(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
 
         self.command(spi, Command::PowerOff)?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.cmd_with_data(spi, Command::DeepSleep, &[0xa5])?;
 
         Ok(())
@@ -175,9 +183,9 @@ where
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.update_achromatic_frame(spi, buffer)?;
+        self.update_achromatic_frame(spi, delay, buffer)?;
 
         // Clear the chromatic layer
         let color = self.color.get_byte_value();
@@ -192,6 +200,7 @@ where
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
@@ -201,9 +210,9 @@ where
         unimplemented!()
     }
 
-    fn display_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         self.command(spi, Command::DisplayRefresh)?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         Ok(())
     }
@@ -220,8 +229,8 @@ where
         Ok(())
     }
 
-    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         let color = DEFAULT_BACKGROUND_COLOR.get_byte_value();
 
         // Clear the black
@@ -238,13 +247,15 @@ where
     fn set_lut(
         &mut self,
         _spi: &mut SPI,
+        _delay: &mut DELAY,
         _refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         Ok(())
     }
 
-    fn is_busy(&self) -> bool {
-        self.interface.is_busy(IS_BUSY_LOW)
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
     }
 }
 
@@ -272,10 +283,6 @@ where
         data: &[u8],
     ) -> Result<(), SPI::Error> {
         self.interface.cmd_with_data(spi, command, data)
-    }
-
-    fn wait_until_idle(&mut self) {
-        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd1in54c/mod.rs
+++ b/src/epd1in54c/mod.rs
@@ -137,7 +137,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;

--- a/src/epd2in13_v2/mod.rs
+++ b/src/epd2in13_v2/mod.rs
@@ -72,9 +72,9 @@ where
 
         if self.refresh == RefreshLut::Quick {
             self.set_vcom_register(spi, (-9).vcom())?;
-            self.wait_until_idle();
+            self.wait_until_idle(spi, delay)?;
 
-            self.set_lut(spi, Some(self.refresh))?;
+            self.set_lut(spi, delay, Some(self.refresh))?;
 
             // Python code does this, not sure why
             // self.cmd_with_data(spi, Command::WriteOtpSelection, &[0, 0, 0, 0, 0x40, 0, 0])?;
@@ -86,7 +86,7 @@ where
                 DisplayUpdateControl2::new().enable_analog().enable_clock(),
             )?;
             self.command(spi, Command::MasterActivation)?;
-            self.wait_until_idle();
+            self.wait_until_idle(spi, delay)?;
 
             self.set_border_waveform(
                 spi,
@@ -97,9 +97,9 @@ where
                 },
             )?;
         } else {
-            self.wait_until_idle();
+            self.wait_until_idle(spi, delay)?;
             self.command(spi, Command::SwReset)?;
-            self.wait_until_idle();
+            self.wait_until_idle(spi, delay)?;
 
             self.set_driver_output(
                 spi,
@@ -119,7 +119,7 @@ where
 
             // Use simple X/Y auto increase
             self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
-            self.set_ram_address_counters(spi, 0, 0)?;
+            self.set_ram_address_counters(spi, delay, 0, 0)?;
 
             self.set_border_waveform(
                 spi,
@@ -142,10 +142,10 @@ where
 
             self.set_gate_line_width(spi, 10)?;
 
-            self.set_lut(spi, Some(self.refresh))?;
+            self.set_lut(spi, delay, Some(self.refresh))?;
         }
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 }
@@ -168,9 +168,10 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error> {
         let mut epd = Epd2in13 {
-            interface: DisplayInterface::new(cs, busy, dc, rst),
+            interface: DisplayInterface::new(cs, busy, dc, rst, delay_ms),
             sleep_mode: DeepSleepMode::Mode1,
             background_color: DEFAULT_BACKGROUND_COLOR,
             refresh: RefreshLut::Full,
@@ -184,8 +185,8 @@ where
         self.init(spi, delay)
     }
 
-    fn sleep(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
 
         // All sample code enables and disables analog/clocks...
         self.set_display_update_control_2(
@@ -206,18 +207,18 @@ where
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         assert!(buffer.len() == buffer_len(WIDTH as usize, HEIGHT as usize));
         self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
-        self.set_ram_address_counters(spi, 0, 0)?;
+        self.set_ram_address_counters(spi, delay, 0, 0)?;
 
         self.cmd_with_data(spi, Command::WriteRam, buffer)?;
 
         if self.refresh == RefreshLut::Full {
             // Always keep the base buffer equal to current if not doing partial refresh.
             self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
-            self.set_ram_address_counters(spi, 0, 0)?;
+            self.set_ram_address_counters(spi, delay, 0, 0)?;
 
             self.cmd_with_data(spi, Command::WriteRamRed, buffer)?;
         }
@@ -230,6 +231,7 @@ where
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
@@ -247,14 +249,14 @@ where
         assert!(self.refresh == RefreshLut::Full);
 
         self.set_ram_area(spi, x, y, x + width, y + height)?;
-        self.set_ram_address_counters(spi, x, y)?;
+        self.set_ram_address_counters(spi, delay, x, y)?;
 
         self.cmd_with_data(spi, Command::WriteRam, buffer)?;
 
         if self.refresh == RefreshLut::Full {
             // Always keep the base buffer equals to current if not doing partial refresh.
             self.set_ram_area(spi, x, y, x + width, y + height)?;
-            self.set_ram_address_counters(spi, x, y)?;
+            self.set_ram_address_counters(spi, delay, x, y)?;
 
             self.cmd_with_data(spi, Command::WriteRamRed, buffer)?;
         }
@@ -264,7 +266,7 @@ where
 
     /// Never use directly this function when using partial refresh, or also
     /// keep the base buffer in syncd using `set_partial_base_buffer` function.
-    fn display_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         if self.refresh == RefreshLut::Full {
             self.set_display_update_control_2(
                 spi,
@@ -279,7 +281,7 @@ where
             self.set_display_update_control_2(spi, DisplayUpdateControl2::new().display())?;
         }
         self.command(spi, Command::MasterActivation)?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         Ok(())
     }
@@ -294,16 +296,16 @@ where
         self.display_frame(spi, delay)?;
 
         if self.refresh == RefreshLut::Quick {
-            self.set_partial_base_buffer(spi, buffer)?;
+            self.set_partial_base_buffer(spi, delay, buffer)?;
         }
         Ok(())
     }
 
-    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         let color = self.background_color.get_byte_value();
 
         self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
-        self.set_ram_address_counters(spi, 0, 0)?;
+        self.set_ram_address_counters(spi, delay, 0, 0)?;
 
         self.command(spi, Command::WriteRam)?;
         self.interface.data_x_times(
@@ -315,7 +317,7 @@ where
         // Always keep the base buffer equals to current if not doing partial refresh.
         if self.refresh == RefreshLut::Full {
             self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
-            self.set_ram_address_counters(spi, 0, 0)?;
+            self.set_ram_address_counters(spi, delay, 0, 0)?;
 
             self.command(spi, Command::WriteRamRed)?;
             self.interface.data_x_times(
@@ -346,6 +348,7 @@ where
     fn set_lut(
         &mut self,
         spi: &mut SPI,
+        _delay: &mut DELAY,
         refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         let buffer = match refresh_rate {
@@ -356,8 +359,9 @@ where
         self.cmd_with_data(spi, Command::WriteLutRegister, buffer)
     }
 
-    fn is_busy(&self) -> bool {
-        self.interface.is_busy(IS_BUSY_LOW)
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
     }
 }
 
@@ -375,11 +379,12 @@ where
     pub fn set_partial_base_buffer(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
     ) -> Result<(), SPI::Error> {
         assert!(buffer_len(WIDTH as usize, HEIGHT as usize) == buffer.len());
         self.set_ram_area(spi, 0, 0, WIDTH - 1, HEIGHT - 1)?;
-        self.set_ram_address_counters(spi, 0, 0)?;
+        self.set_ram_address_counters(spi, delay, 0, 0)?;
 
         self.cmd_with_data(spi, Command::WriteRamRed, buffer)?;
         Ok(())
@@ -532,10 +537,11 @@ where
     fn set_ram_address_counters(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         x: u32,
         y: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.cmd_with_data(spi, Command::SetRamXAddressCounter, &[(x >> 3) as u8])?;
 
         self.cmd_with_data(
@@ -557,10 +563,6 @@ where
         data: &[u8],
     ) -> Result<(), SPI::Error> {
         self.interface.cmd_with_data(spi, command, data)
-    }
-
-    fn wait_until_idle(&mut self) {
-        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 }
 

--- a/src/epd2in13_v2/mod.rs
+++ b/src/epd2in13_v2/mod.rs
@@ -168,7 +168,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let mut epd = Epd2in13 {
             interface: DisplayInterface::new(cs, busy, dc, rst, delay_ms),

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -20,7 +20,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd2in13bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
+//!let mut epd = Epd2in13bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!// This display is for the black/white/chromatic pixels
@@ -212,7 +212,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -20,7 +20,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd2in13bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+//!let mut epd = Epd2in13bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!// This display is for the black/white/chromatic pixels
@@ -39,6 +39,7 @@
 //!// Display updated frame
 //!epd.update_color_frame(
 //!    &mut spi,
+//!    &mut delay,
 //!    &tricolor_display.bw_buffer(),
 //!    &tricolor_display.chromatic_buffer()
 //!)?;
@@ -119,7 +120,7 @@ where
         // power on
         self.command(spi, Command::PowerOn)?;
         delay.delay_ms(5);
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         // set the panel settings
         self.cmd_with_data(spi, Command::PanelSetting, &[0x8F])?;
@@ -135,7 +136,7 @@ where
 
         self.cmd_with_data(spi, Command::VcmDcSetting, &[0x0A])?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         Ok(())
     }
@@ -154,17 +155,23 @@ where
     fn update_color_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         black: &[u8],
         chromatic: &[u8],
     ) -> Result<(), SPI::Error> {
-        self.update_achromatic_frame(spi, black)?;
-        self.update_chromatic_frame(spi, chromatic)
+        self.update_achromatic_frame(spi, delay, black)?;
+        self.update_chromatic_frame(spi, delay, chromatic)
     }
 
     /// Update only the black/white data of the display.
     ///
     /// Finish by calling `update_chromatic_frame`.
-    fn update_achromatic_frame(&mut self, spi: &mut SPI, black: &[u8]) -> Result<(), SPI::Error> {
+    fn update_achromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        _delay: &mut DELAY,
+        black: &[u8],
+    ) -> Result<(), SPI::Error> {
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
         self.interface.data(spi, black)?;
         Ok(())
@@ -176,12 +183,13 @@ where
     fn update_chromatic_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         chromatic: &[u8],
     ) -> Result<(), SPI::Error> {
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
         self.interface.data(spi, chromatic)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 }
@@ -204,8 +212,9 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error> {
-        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;
 
         let mut epd = Epd2in13bc { interface, color };
@@ -215,7 +224,7 @@ where
         Ok(epd)
     }
 
-    fn sleep(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         // Section 8.2 from datasheet
         self.interface.cmd_with_data(
             spi,
@@ -225,7 +234,7 @@ where
 
         self.command(spi, Command::PowerOff)?;
         // The example STM code from Github has a wait after PowerOff
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         self.cmd_with_data(spi, Command::DeepSleep, &[0xA5])?;
 
@@ -256,7 +265,7 @@ where
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
 
@@ -268,7 +277,7 @@ where
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
         self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 
@@ -276,6 +285,7 @@ where
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
@@ -285,10 +295,10 @@ where
         Ok(())
     }
 
-    fn display_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         self.command(spi, Command::DisplayRefresh)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 
@@ -303,7 +313,7 @@ where
         Ok(())
     }
 
-    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         self.send_resolution(spi)?;
 
         let color = DEFAULT_BACKGROUND_COLOR.get_byte_value();
@@ -317,20 +327,22 @@ where
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
         self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 
     fn set_lut(
         &mut self,
         _spi: &mut SPI,
+        _delay: &mut DELAY,
         _refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         Ok(())
     }
 
-    fn is_busy(&self) -> bool {
-        self.interface.is_busy(IS_BUSY_LOW)
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
     }
 }
 
@@ -358,10 +370,6 @@ where
         data: &[u8],
     ) -> Result<(), SPI::Error> {
         self.interface.cmd_with_data(spi, command, data)
-    }
-
-    fn wait_until_idle(&mut self) {
-        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd2in7b/mod.rs
+++ b/src/epd2in7b/mod.rs
@@ -127,7 +127,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;

--- a/src/epd2in7b/mod.rs
+++ b/src/epd2in7b/mod.rs
@@ -388,6 +388,7 @@ where
     }
 
     /// Update black/achromatic frame
+    #[allow(clippy::too_many_arguments)]
     pub fn update_partial_achromatic_frame(
         &mut self,
         spi: &mut SPI,
@@ -419,6 +420,7 @@ where
     }
 
     /// Update partial chromatic/red frame
+    #[allow(clippy::too_many_arguments)]
     pub fn update_partial_chromatic_frame(
         &mut self,
         spi: &mut SPI,

--- a/src/epd2in9/mod.rs
+++ b/src/epd2in9/mod.rs
@@ -21,7 +21,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd2in9::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
+//!let mut epd = Epd2in9::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!let mut display = Display2in9::default();
@@ -158,7 +158,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
 

--- a/src/epd2in9_v2/mod.rs
+++ b/src/epd2in9_v2/mod.rs
@@ -22,7 +22,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd2in9::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
+//!let mut epd = Epd2in9::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!let mut display = Display2in9::default();
@@ -171,7 +171,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
 

--- a/src/epd2in9bc/mod.rs
+++ b/src/epd2in9bc/mod.rs
@@ -20,7 +20,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd2in9bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+//!let mut epd = Epd2in9bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!// This display is for the black/white pixels
@@ -43,6 +43,7 @@
 //!// Display updated frame
 //!epd.update_color_frame(
 //!    &mut spi,
+//!    &mut delay,
 //!    &mono_display.buffer(),
 //!    &chromatic_display.buffer()
 //!)?;
@@ -118,7 +119,7 @@ where
         // power on
         self.command(spi, Command::PowerOn)?;
         delay.delay_ms(5);
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         // set the panel settings
         self.cmd_with_data(spi, Command::PanelSetting, &[0x8F])?;
@@ -134,7 +135,7 @@ where
 
         self.cmd_with_data(spi, Command::VcmDcSetting, &[0x0A])?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         Ok(())
     }
@@ -153,17 +154,23 @@ where
     fn update_color_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         black: &[u8],
         chromatic: &[u8],
     ) -> Result<(), SPI::Error> {
-        self.update_achromatic_frame(spi, black)?;
-        self.update_chromatic_frame(spi, chromatic)
+        self.update_achromatic_frame(spi, delay, black)?;
+        self.update_chromatic_frame(spi, delay, chromatic)
     }
 
     /// Update only the black/white data of the display.
     ///
     /// Finish by calling `update_chromatic_frame`.
-    fn update_achromatic_frame(&mut self, spi: &mut SPI, black: &[u8]) -> Result<(), SPI::Error> {
+    fn update_achromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        _delay: &mut DELAY,
+        black: &[u8],
+    ) -> Result<(), SPI::Error> {
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
         self.interface.data(spi, black)?;
         Ok(())
@@ -175,12 +182,13 @@ where
     fn update_chromatic_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         chromatic: &[u8],
     ) -> Result<(), SPI::Error> {
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
         self.interface.data(spi, chromatic)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 }
@@ -203,8 +211,9 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error> {
-        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;
 
         let mut epd = Epd2in9bc { interface, color };
@@ -214,7 +223,7 @@ where
         Ok(epd)
     }
 
-    fn sleep(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         // Section 8.2 from datasheet
         self.interface.cmd_with_data(
             spi,
@@ -224,7 +233,7 @@ where
 
         self.command(spi, Command::PowerOff)?;
         // The example STM code from Github has a wait after PowerOff
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         self.cmd_with_data(spi, Command::DeepSleep, &[0xA5])?;
 
@@ -255,7 +264,7 @@ where
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
 
@@ -267,7 +276,7 @@ where
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
         self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 
@@ -275,6 +284,7 @@ where
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
@@ -284,10 +294,10 @@ where
         Ok(())
     }
 
-    fn display_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         self.command(spi, Command::DisplayRefresh)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 
@@ -302,7 +312,7 @@ where
         Ok(())
     }
 
-    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         self.send_resolution(spi)?;
 
         let color = DEFAULT_BACKGROUND_COLOR.get_byte_value();
@@ -316,20 +326,22 @@ where
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
         self.interface.data_x_times(spi, color, NUM_DISPLAY_BITS)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 
     fn set_lut(
         &mut self,
         _spi: &mut SPI,
+        _delay: &mut DELAY,
         _refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         Ok(())
     }
 
-    fn is_busy(&self) -> bool {
-        self.interface.is_busy(IS_BUSY_LOW)
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
     }
 }
 
@@ -357,10 +369,6 @@ where
         data: &[u8],
     ) -> Result<(), SPI::Error> {
         self.interface.cmd_with_data(spi, command, data)
-    }
-
-    fn wait_until_idle(&mut self) {
-        self.interface.wait_until_idle(IS_BUSY_LOW);
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd2in9bc/mod.rs
+++ b/src/epd2in9bc/mod.rs
@@ -20,7 +20,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd2in9bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
+//!let mut epd = Epd2in9bc::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!// This display is for the black/white pixels
@@ -211,7 +211,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -384,6 +384,7 @@ where
         self.send_data(spi, &[h as u8])
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn set_lut_helper(
         &mut self,
         spi: &mut SPI,

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -25,7 +25,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+//!let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!let mut display = Display4in2::default();
@@ -118,7 +118,7 @@ where
         // power on
         self.command(spi, Command::PowerOn)?;
         delay.delay_ms(5);
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         // set the panel settings
         self.cmd_with_data(spi, Command::PanelSetting, &[0x3F])?;
@@ -138,9 +138,9 @@ where
         self.interface
             .cmd_with_data(spi, Command::VcomAndDataIntervalSetting, &[0x97])?;
 
-        self.set_lut(spi, None)?;
+        self.set_lut(spi, delay, None)?;
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 }
@@ -163,8 +163,9 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error> {
-        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;
 
         let mut epd = Epd4in2 {
@@ -178,12 +179,8 @@ where
         Ok(epd)
     }
 
-    fn wake_up(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.init(spi, delay)
-    }
-
-    fn sleep(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         self.interface
             .cmd_with_data(spi, Command::VcomAndDataIntervalSetting, &[0x17])?; //border floating
         self.command(spi, Command::VcmDcSetting)?; // VCOM to 0V
@@ -195,19 +192,39 @@ where
         }
 
         self.command(spi, Command::PowerOff)?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.interface
             .cmd_with_data(spi, Command::DeepSleep, &[0xA5])?;
         Ok(())
+    }
+
+    fn wake_up(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.init(spi, delay)
+    }
+
+    fn set_background_color(&mut self, color: Color) {
+        self.color = color;
+    }
+
+    fn background_color(&self) -> &Color {
+        &self.color
+    }
+
+    fn width(&self) -> u32 {
+        WIDTH
+    }
+
+    fn height(&self) -> u32 {
+        HEIGHT
     }
 
     fn update_frame(
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         let color_value = self.color.get_byte_value();
 
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
@@ -222,13 +239,14 @@ where
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
         width: u32,
         height: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         if buffer.len() as u32 != width / 8 * height {
             //TODO: panic!! or sth like that
             //return Err("Wrong buffersize");
@@ -265,8 +283,8 @@ where
         Ok(())
     }
 
-    fn display_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         self.command(spi, Command::DisplayRefresh)?;
         Ok(())
     }
@@ -282,8 +300,8 @@ where
         Ok(())
     }
 
-    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         self.send_resolution(spi)?;
 
         let color_value = self.color.get_byte_value();
@@ -298,25 +316,10 @@ where
         Ok(())
     }
 
-    fn set_background_color(&mut self, color: Color) {
-        self.color = color;
-    }
-
-    fn background_color(&self) -> &Color {
-        &self.color
-    }
-
-    fn width(&self) -> u32 {
-        WIDTH
-    }
-
-    fn height(&self) -> u32 {
-        HEIGHT
-    }
-
     fn set_lut(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         if let Some(refresh_lut) = refresh_rate {
@@ -324,10 +327,11 @@ where
         }
         match self.refresh {
             RefreshLut::Full => {
-                self.set_lut_helper(spi, &LUT_VCOM0, &LUT_WW, &LUT_BW, &LUT_WB, &LUT_BB)
+                self.set_lut_helper(spi, delay, &LUT_VCOM0, &LUT_WW, &LUT_BW, &LUT_WB, &LUT_BB)
             }
             RefreshLut::Quick => self.set_lut_helper(
                 spi,
+                delay,
                 &LUT_VCOM0_QUICK,
                 &LUT_WW_QUICK,
                 &LUT_BW_QUICK,
@@ -337,8 +341,9 @@ where
         }
     }
 
-    fn is_busy(&self) -> bool {
-        self.interface.is_busy(IS_BUSY_LOW)
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
     }
 }
 
@@ -368,10 +373,6 @@ where
         self.interface.cmd_with_data(spi, command, data)
     }
 
-    fn wait_until_idle(&mut self) {
-        self.interface.wait_until_idle(IS_BUSY_LOW);
-    }
-
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
         let w = self.width();
         let h = self.height();
@@ -386,13 +387,14 @@ where
     fn set_lut_helper(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         lut_vcom: &[u8],
         lut_ww: &[u8],
         lut_bw: &[u8],
         lut_wb: &[u8],
         lut_bb: &[u8],
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         // LUT VCOM
         self.cmd_with_data(spi, Command::LutForVcom, lut_vcom)?;
 
@@ -454,9 +456,9 @@ where
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
 
@@ -470,9 +472,9 @@ where
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         // self.send_resolution(spi)?;
 
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
@@ -505,13 +507,14 @@ where
     fn update_partial_old_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
         width: u32,
         height: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         if buffer.len() as u32 != width / 8 * height {
             //TODO: panic!! or sth like that
@@ -535,13 +538,14 @@ where
     fn update_partial_new_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
         width: u32,
         height: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         if buffer.len() as u32 != width / 8 * height {
             //TODO: panic!! or sth like that
             //return Err("Wrong buffersize");
@@ -560,12 +564,13 @@ where
     fn clear_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         x: u32,
         y: u32,
         width: u32,
         height: u32,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.send_resolution(spi)?;
 
         let color_value = self.color.get_byte_value();

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -25,7 +25,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
+//!let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!let mut display = Display4in2::default();
@@ -163,7 +163,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;

--- a/src/epd5in65f/mod.rs
+++ b/src/epd5in65f/mod.rs
@@ -96,7 +96,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;

--- a/src/epd5in65f/mod.rs
+++ b/src/epd5in65f/mod.rs
@@ -234,9 +234,7 @@ where
     }
 
     fn wait_busy_low(&mut self, delay: &mut DELAY) {
-        while self.interface.is_busy(false) {
-            delay.delay_ms(5);
-        }
+        self.interface.wait_until_idle(delay, false);
     }
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
         let w = self.width();

--- a/src/epd5in83b_v2/mod.rs
+++ b/src/epd5in83b_v2/mod.rs
@@ -155,7 +155,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;

--- a/src/epd7in5/mod.rs
+++ b/src/epd7in5/mod.rs
@@ -114,7 +114,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -62,14 +62,14 @@ where
         // and as per specs:
         // https://www.waveshare.com/w/upload/2/27/7inch_HD_e-Paper_Specification.pdf
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.command(spi, Command::SwReset)?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         self.cmd_with_data(spi, Command::AutoWriteRed, &[0xF7])?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.cmd_with_data(spi, Command::AutoWriteBw, &[0xF7])?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         self.cmd_with_data(spi, Command::SoftStart, &[0xAE, 0xC7, 0xC3, 0xC0, 0x40])?;
 
@@ -87,7 +87,7 @@ where
         self.cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xB1])?;
 
         self.command(spi, Command::MasterActivation)?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
 
         self.cmd_with_data(spi, Command::SetRamXAc, &[0x00, 0x00])?;
         self.cmd_with_data(spi, Command::SetRamYAc, &[0x00, 0x00])?;
@@ -114,8 +114,9 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error> {
-        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;
 
         let mut epd = Epd7in5 { interface, color };
@@ -129,8 +130,8 @@ where
         self.init(spi, delay)
     }
 
-    fn sleep(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
         self.cmd_with_data(spi, Command::DeepSleep, &[0x01])?;
         Ok(())
     }
@@ -139,9 +140,9 @@ where
         &mut self,
         spi: &mut SPI,
         buffer: &[u8],
-        _delay: &mut DELAY,
+        delay: &mut DELAY,
     ) -> Result<(), SPI::Error> {
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.cmd_with_data(spi, Command::SetRamYAc, &[0x00, 0x00])?;
         self.cmd_with_data(spi, Command::WriteRamBw, buffer)?;
         self.cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xF7])?;
@@ -151,6 +152,7 @@ where
     fn update_partial_frame(
         &mut self,
         _spi: &mut SPI,
+        _delay: &mut DELAY,
         _buffer: &[u8],
         _x: u32,
         _y: u32,
@@ -160,9 +162,9 @@ where
         unimplemented!();
     }
 
-    fn display_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         self.command(spi, Command::MasterActivation)?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 
@@ -177,11 +179,11 @@ where
         Ok(())
     }
 
-    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         let pixel_count = WIDTH * HEIGHT / 8;
         let background_color_byte = self.color.get_byte_value();
 
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         self.cmd_with_data(spi, Command::SetRamYAc, &[0x00, 0x00])?;
 
         for cmd in &[Command::WriteRamBw, Command::WriteRamRed] {
@@ -192,7 +194,7 @@ where
 
         self.cmd_with_data(spi, Command::DisplayUpdateControl2, &[0xF7])?;
         self.command(spi, Command::MasterActivation)?;
-        self.wait_until_idle();
+        self.wait_until_idle(spi, delay)?;
         Ok(())
     }
 
@@ -215,13 +217,15 @@ where
     fn set_lut(
         &mut self,
         _spi: &mut SPI,
+        _delay: &mut DELAY,
         _refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         unimplemented!();
     }
 
-    fn is_busy(&self) -> bool {
-        self.interface.is_busy(IS_BUSY_LOW)
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
     }
 }
 
@@ -245,10 +249,6 @@ where
         data: &[u8],
     ) -> Result<(), SPI::Error> {
         self.interface.cmd_with_data(spi, command, data)
-    }
-
-    fn wait_until_idle(&mut self) {
-        self.interface.wait_until_idle(IS_BUSY_LOW)
     }
 }
 

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -114,7 +114,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;

--- a/src/epd7in5_v2/mod.rs
+++ b/src/epd7in5_v2/mod.rs
@@ -96,8 +96,9 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error> {
-        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;
 
         let mut epd = Epd7in5 { interface, color };
@@ -133,6 +134,7 @@ where
     fn update_partial_frame(
         &mut self,
         _spi: &mut SPI,
+        _delay: &mut DELAY,
         _buffer: &[u8],
         _x: u32,
         _y: u32,
@@ -192,13 +194,19 @@ where
     fn set_lut(
         &mut self,
         _spi: &mut SPI,
+        _delay: &mut DELAY,
         _refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error> {
         unimplemented!();
     }
 
-    fn is_busy(&self) -> bool {
-        self.interface.is_busy(IS_BUSY_LOW)
+    fn wait_until_idle(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        while self.interface.is_busy(IS_BUSY_LOW) {
+            // ignore error because it doesn't change anything and we still check busy
+            self.interface.cmd(spi, Command::GetStatus)?;
+            delay.delay_ms(20);
+        }
+        Ok(())
     }
 }
 
@@ -226,14 +234,6 @@ where
         data: &[u8],
     ) -> Result<(), SPI::Error> {
         self.interface.cmd_with_data(spi, command, data)
-    }
-
-    fn wait_until_idle(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
-        while self.interface.is_busy(IS_BUSY_LOW) {
-            self.interface.cmd(spi, Command::GetStatus)?;
-            delay.delay_ms(20);
-        }
-        Ok(())
     }
 
     fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {

--- a/src/epd7in5_v2/mod.rs
+++ b/src/epd7in5_v2/mod.rs
@@ -96,7 +96,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;
@@ -201,12 +201,8 @@ where
     }
 
     fn wait_until_idle(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
-        while self.interface.is_busy(IS_BUSY_LOW) {
-            // ignore error because it doesn't change anything and we still check busy
-            self.interface.cmd(spi, Command::GetStatus)?;
-            delay.delay_ms(20);
-        }
-        Ok(())
+        self.interface
+            .wait_until_idle_with_cmd(spi, delay, IS_BUSY_LOW, Command::GetStatus)
     }
 }
 

--- a/src/epd7in5_v3/mod.rs
+++ b/src/epd7in5_v3/mod.rs
@@ -158,7 +158,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error> {
         let interface = DisplayInterface::new(cs, busy, dc, rst, delay_ms);
         let color = DEFAULT_BACKGROUND_COLOR;
@@ -274,11 +274,8 @@ where
     }
 
     fn wait_until_idle(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
-        while self.interface.is_busy(IS_BUSY_LOW) {
-            self.interface.cmd(spi, Command::GetStatus)?;
-            delay.delay_ms(20);
-        }
-        Ok(())
+        self.interface
+            .wait_until_idle_with_cmd(spi, delay, IS_BUSY_LOW, Command::GetStatus)
     }
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -33,6 +33,9 @@ where
     RST: OutputPin,
     DELAY: DelayMs<u8>,
 {
+    /// Creates a new `DisplayInterface` struct
+    ///
+    /// If no delay is given, a default delay of 10ms is used.
     pub fn new(cs: CS, busy: BUSY, dc: DC, rst: RST, delay_ms: Option<u8>) -> Self {
         // default delay of 10ms
         let delay_ms = delay_ms.unwrap_or(10);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd1in54::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+//!let mut epd = Epd1in54::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!let mut display = Display1in54::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!# let mut delay = delay::MockNoop::new();
 //!
 //!// Setup EPD
-//!let mut epd = Epd1in54::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
+//!let mut epd = Epd1in54::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
 //!
 //!// Use display graphics from embedded-graphics
 //!let mut display = Display1in54::default();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -200,6 +200,7 @@ where
     /// (x,y) is the top left corner
     ///
     /// BUFFER needs to be of size: width / 8 * height !
+    #[allow(clippy::too_many_arguments)]
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
@@ -332,6 +333,7 @@ where
     ) -> Result<(), SPI::Error>;
 
     /// Updates the old frame for a portion of the display.
+    #[allow(clippy::too_many_arguments)]
     fn update_partial_old_frame(
         &mut self,
         spi: &mut SPI,
@@ -344,6 +346,7 @@ where
     ) -> Result<(), SPI::Error>;
 
     /// Updates the new frame for a portion of the display.
+    #[allow(clippy::too_many_arguments)]
     fn update_partial_new_frame(
         &mut self,
         spi: &mut SPI,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,7 +6,7 @@ use embedded_hal::{
 
 /// All commands need to have this trait which gives the address of the command
 /// which needs to be send via SPI with activated CommandsPin (Data/Command Pin in CommandMode)
-pub(crate) trait Command {
+pub(crate) trait Command: Copy {
     fn address(self) -> u8;
 }
 
@@ -116,7 +116,7 @@ where
 ///# let mut delay = delay::MockNoop::new();
 ///
 ///// Setup EPD
-///let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
+///let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
 ///
 ///// Use display graphics from embedded-graphics
 ///let mut display = Display4in2::default();
@@ -150,7 +150,8 @@ where
     /// Creates a new driver from a SPI peripheral, CS Pin, Busy InputPin, DC
     ///
     /// delay_ms is the number of ms the idle loop should sleep on.
-    /// Setting this to 0 implies busy waiting.
+    /// Setting it to 0 implies busy waiting.
+    /// Setting it to None means use a default value.
     ///
     /// This already initialises the device.
     fn new(
@@ -160,7 +161,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
-        delay_ms: u8,
+        delay_ms: Option<u8>,
     ) -> Result<Self, SPI::Error>
     where
         Self: Sized;
@@ -279,7 +280,7 @@ where
 ///# let mut delay = delay::MockNoop::new();
 ///#
 ///# // Setup EPD
-///# let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
+///# let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, None)?;
 ///let (x, y, frame_width, frame_height) = (20, 40, 80,80);
 ///
 ///let mut buffer = [DEFAULT_BACKGROUND_COLOR.get_byte_value(); 80 / 8 * 80];

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -65,6 +65,7 @@ where
     fn update_color_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         black: &[u8],
         chromatic: &[u8],
     ) -> Result<(), SPI::Error>;
@@ -72,14 +73,23 @@ where
     /// Update only the black/white data of the display.
     ///
     /// This must be finished by calling `update_chromatic_frame`.
-    fn update_achromatic_frame(&mut self, spi: &mut SPI, black: &[u8]) -> Result<(), SPI::Error>;
+    fn update_achromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+        black: &[u8],
+    ) -> Result<(), SPI::Error>;
 
     /// Update only the chromatic data of the display.
     ///
     /// This should be preceded by a call to `update_achromatic_frame`.
     /// This data takes precedence over the black/white data.
-    fn update_chromatic_frame(&mut self, spi: &mut SPI, chromatic: &[u8])
-        -> Result<(), SPI::Error>;
+    fn update_chromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error>;
 }
 
 /// All the functions to interact with the EPDs
@@ -106,7 +116,7 @@ where
 ///# let mut delay = delay::MockNoop::new();
 ///
 ///// Setup EPD
-///let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+///let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
 ///
 ///// Use display graphics from embedded-graphics
 ///let mut display = Display4in2::default();
@@ -139,6 +149,9 @@ where
     type DisplayColor;
     /// Creates a new driver from a SPI peripheral, CS Pin, Busy InputPin, DC
     ///
+    /// delay_ms is the number of ms the idle loop should sleep on.
+    /// Setting this to 0 implies busy waiting.
+    ///
     /// This already initialises the device.
     fn new(
         spi: &mut SPI,
@@ -147,6 +160,7 @@ where
         dc: DC,
         rst: RST,
         delay: &mut DELAY,
+        delay_ms: u8,
     ) -> Result<Self, SPI::Error>
     where
         Self: Sized;
@@ -189,6 +203,7 @@ where
     fn update_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
@@ -225,15 +240,14 @@ where
     fn set_lut(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         refresh_rate: Option<RefreshLut>,
     ) -> Result<(), SPI::Error>;
 
-    /// Checks if the display is busy transmitting data
+    /// Wait until the display has stopped processing data
     ///
-    /// This is normally handled by the more complicated commands themselves,
-    /// but in the case you send data and commands directly you might need to check
-    /// if the device is still busy
-    fn is_busy(&self) -> bool;
+    /// You can call this to make sure a frame is displayed before goin further
+    fn wait_until_idle(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error>;
 }
 
 /// Allows quick refresh support for displays that support it; lets you send both
@@ -264,19 +278,19 @@ where
 ///# let mut delay = delay::MockNoop::new();
 ///#
 ///# // Setup EPD
-///# let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay)?;
+///# let mut epd = Epd4in2::new(&mut spi, cs_pin, busy_in, dc, rst, &mut delay, 5)?;
 ///let (x, y, frame_width, frame_height) = (20, 40, 80,80);
 ///
 ///let mut buffer = [DEFAULT_BACKGROUND_COLOR.get_byte_value(); 80 / 8 * 80];
 ///let mut display = VarDisplay::new(frame_width, frame_height, &mut buffer,false).unwrap();
 ///
-///epd.update_partial_old_frame(&mut spi, display.buffer(), x, y, frame_width, frame_height)
+///epd.update_partial_old_frame(&mut spi, &mut delay, display.buffer(), x, y, frame_width, frame_height)
 ///  .ok();
 ///
 ///display.clear(Color::White).ok();
 ///// Execute drawing commands here.
 ///
-///epd.update_partial_new_frame(&mut spi, display.buffer(), x, y, frame_width, frame_height)
+///epd.update_partial_new_frame(&mut spi, &mut delay, display.buffer(), x, y, frame_width, frame_height)
 ///  .ok();
 ///# Ok(())
 ///# }
@@ -321,6 +335,7 @@ where
     fn update_partial_old_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
@@ -332,6 +347,7 @@ where
     fn update_partial_new_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         buffer: &[u8],
         x: u32,
         y: u32,
@@ -344,6 +360,7 @@ where
     fn clear_partial_frame(
         &mut self,
         spi: &mut SPI,
+        delay: &mut DELAY,
         x: u32,
         y: u32,
         width: u32,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -149,9 +149,9 @@ where
     type DisplayColor;
     /// Creates a new driver from a SPI peripheral, CS Pin, Busy InputPin, DC
     ///
-    /// delay_ms is the number of ms the idle loop should sleep on.
+    /// `delay_ms` is the number of ms the idle loop should sleep on.
     /// Setting it to 0 implies busy waiting.
-    /// Setting it to None means use a default value.
+    /// Setting it to None means a default value is used.
     ///
     /// This already initialises the device.
     fn new(


### PR DESCRIPTION
The delay structure is missing in many places where wait_until_idle is needed, so i added it everywhere.

Moreover, the default is to busy loop, but it can be very interesting on microcontrolers to sleep instead, either to save energy or to give time to another task. Especially with large displays where the refresh time can take several seconds. So I made the sleep time a parameter the user can control.

I also made `wait_until_idle` public, because, even if methods call it when it is mandatory, the user can still want to call it to make sure last data has been processed before going on.