### PR TITLE
Migrate to rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "epd-waveshare"
 readme = "README.md"
 repository = "https://github.com/Caemor/epd-waveshare.git"
 version = "0.5.0"
-edition = "2018"
+edition = "2021"
 
 [badges]
 # travis-ci = { repository = "caemor/epd-waveshare" }


### PR DESCRIPTION
I like using the last version of rust, even if nothing changes