### PR TITLE
Add conversion from BinaryColor to Color

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -140,6 +140,16 @@ impl From<BinaryColor> for OctColor {
 }
 
 #[cfg(feature = "graphics")]
+impl From<BinaryColor> for Color {
+    fn from(b: BinaryColor) -> Color {
+        match b {
+            BinaryColor::On => Color::Black,
+            BinaryColor::Off => Color::White,
+        }
+    }
+}
+
+#[cfg(feature = "graphics")]
 impl From<OctColor> for embedded_graphics_core::pixelcolor::Rgb888 {
     fn from(b: OctColor) -> Self {
         let (r, g, b) = b.rgb();


### PR DESCRIPTION
Without this we get an error when drawing BinaryColor images onto epd1in54_v2 and probably other BW displays.