### PR TITLE
[epd1in54_v2] Do enter deep sleep when epd.sleep() is invoked

### DIFF
--- a/src/epd1in54_v2/mod.rs
+++ b/src/epd1in54_v2/mod.rs
@@ -137,10 +137,8 @@ where
 
     fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
         self.wait_until_idle(spi, delay)?;
-        // 0x00 for Normal mode (Power on Reset), 0x01 for Deep Sleep Mode
-        //TODO: is 0x00 needed here or would 0x01 be even more efficient?
         self.interface
-            .cmd_with_data(spi, Command::DeepSleepMode, &[0x00])?;
+            .cmd_with_data(spi, Command::DeepSleepMode, &[0x01])?;
         Ok(())
     }
 


### PR DESCRIPTION
The documentation for [`WaveshareDisplay::sleep()`](https://docs.rs/epd-waveshare/latest/epd_waveshare/prelude/trait.WaveshareDisplay.html#tymethod.sleep) states that the function puts the device in deep sleep.  According to the documentation for this display, this requires sending a 0x1.  Tested on a device, and observed a drop of standby current from ~10 uA to ~1 uA.

This probably applies to all the displays that internally use the SSD1681 controller, but I have no way to test.