### PR TITLE
WIP: Fix 7in5(HD) by allowing blockwise data to be written

### DIFF
--- a/src/epd1in54/mod.rs
+++ b/src/epd1in54/mod.rs
@@ -52,6 +52,7 @@ pub const HEIGHT: u32 = 200;
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 //const DPI: u16 = 184;
 const IS_BUSY_LOW: bool = false;
+const SINGLE_BYTE_WRITE: bool = true;
 
 use embedded_hal::{
     blocking::{delay::*, spi::Write},
@@ -83,7 +84,7 @@ pub type Display1in54 = crate::graphics::Display<
 /// Epd1in54 driver
 pub struct Epd1in54<SPI, CS, BUSY, DC, RST, DELAY> {
     /// SPI
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Color
     background_color: Color,
     /// Refresh LUT

--- a/src/epd1in54_v2/mod.rs
+++ b/src/epd1in54_v2/mod.rs
@@ -9,6 +9,7 @@ pub const HEIGHT: u32 = 200;
 /// Default Background Color
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = false;
+const SINGLE_BYTE_WRITE: bool = true;
 
 use embedded_hal::{
     blocking::{delay::*, spi::Write},
@@ -32,7 +33,7 @@ pub use crate::epd1in54::Display1in54;
 /// Epd1in54 driver
 pub struct Epd1in54<SPI, CS, BUSY, DC, RST, DELAY> {
     /// SPI
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Color
     background_color: Color,
 

--- a/src/epd1in54b/mod.rs
+++ b/src/epd1in54b/mod.rs
@@ -21,6 +21,7 @@ pub const HEIGHT: u32 = 200;
 /// Default Background Color (white)
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = true;
+const SINGLE_BYTE_WRITE: bool = true;
 
 use crate::color::Color;
 
@@ -41,7 +42,7 @@ pub type Display1in54b = crate::graphics::Display<
 
 /// Epd1in54b driver
 pub struct Epd1in54b<SPI, CS, BUSY, DC, RST, DELAY> {
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     color: Color,
 }
 

--- a/src/epd1in54c/mod.rs
+++ b/src/epd1in54c/mod.rs
@@ -18,6 +18,7 @@ pub const HEIGHT: u32 = 152;
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = true;
 const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
+const SINGLE_BYTE_WRITE: bool = true;
 
 use crate::color::Color;
 
@@ -38,7 +39,7 @@ pub type Display1in54c = crate::graphics::Display<
 
 /// Epd1in54c driver
 pub struct Epd1in54c<SPI, CS, BUSY, DC, RST, DELAY> {
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     color: Color,
 }
 

--- a/src/epd2in13_v2/mod.rs
+++ b/src/epd2in13_v2/mod.rs
@@ -47,12 +47,13 @@ pub const HEIGHT: u32 = 250;
 /// Default Background Color
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = false;
+const SINGLE_BYTE_WRITE: bool = true;
 
 /// Epd2in13 (V2) driver
 ///
 pub struct Epd2in13<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
 
     sleep_mode: DeepSleepMode,
 

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -76,6 +76,7 @@ const WHITE_BORDER: u8 = 0x70;
 const BLACK_BORDER: u8 = 0x30;
 const CHROMATIC_BORDER: u8 = 0xb0;
 const FLOATING_BORDER: u8 = 0xF0;
+const SINGLE_BYTE_WRITE: bool = true;
 
 use crate::color::TriColor;
 
@@ -95,7 +96,7 @@ pub type Display2in13bc = crate::graphics::Display<
 
 /// Epd2in13bc driver
 pub struct Epd2in13bc<SPI, CS, BUSY, DC, RST, DELAY> {
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     color: TriColor,
 }
 

--- a/src/epd2in7b/mod.rs
+++ b/src/epd2in7b/mod.rs
@@ -23,6 +23,7 @@ pub const HEIGHT: u32 = 264;
 /// Default Background Color
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = true;
+const SINGLE_BYTE_WRITE: bool = true;
 
 use crate::color::Color;
 
@@ -44,7 +45,7 @@ pub type Display2in7b = crate::graphics::Display<
 /// Epd2in7b driver
 pub struct Epd2in7b<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Background Color
     color: Color,
 }

--- a/src/epd2in9/mod.rs
+++ b/src/epd2in9/mod.rs
@@ -48,6 +48,7 @@ pub const HEIGHT: u32 = 296;
 /// Default Background Color (white)
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = false;
+const SINGLE_BYTE_WRITE: bool = true;
 
 use embedded_hal::{
     blocking::{delay::*, spi::Write},
@@ -80,7 +81,7 @@ pub type Display2in9 = crate::graphics::Display<
 ///
 pub struct Epd2in9<SPI, CS, BUSY, DC, RST, DELAY> {
     /// SPI
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Color
     background_color: Color,
     /// Refresh LUT

--- a/src/epd2in9_v2/mod.rs
+++ b/src/epd2in9_v2/mod.rs
@@ -61,6 +61,7 @@ pub const HEIGHT: u32 = 296;
 /// Default Background Color (white)
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = false;
+const SINGLE_BYTE_WRITE: bool = true;
 
 const LUT_PARTIAL_2IN9: [u8; 159] = [
     0x0, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80, 0x80, 0x0, 0x0, 0x0, 0x0,
@@ -103,7 +104,7 @@ pub type Display2in9 = crate::graphics::Display<
 ///
 pub struct Epd2in9<SPI, CS, BUSY, DC, RST, DELAY> {
     /// SPI
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Color
     background_color: Color,
     /// Refresh LUT

--- a/src/epd2in9bc/mod.rs
+++ b/src/epd2in9bc/mod.rs
@@ -79,6 +79,7 @@ const WHITE_BORDER: u8 = 0x70;
 const BLACK_BORDER: u8 = 0x30;
 const CHROMATIC_BORDER: u8 = 0xb0;
 const FLOATING_BORDER: u8 = 0xF0;
+const SINGLE_BYTE_WRITE: bool = true;
 
 use crate::color::{Color, TriColor};
 
@@ -99,7 +100,7 @@ pub type Display2in9bc = crate::graphics::Display<
 
 /// Epd2in9bc driver
 pub struct Epd2in9bc<SPI, CS, BUSY, DC, RST, DELAY> {
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     color: Color,
 }
 

--- a/src/epd3in7/mod.rs
+++ b/src/epd3in7/mod.rs
@@ -29,6 +29,8 @@ pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 
 const IS_BUSY_LOW: bool = false;
 
+const SINGLE_BYTE_WRITE: bool = true;
+
 /// Display with Fullsize buffer for use with the 3in7 EPD
 #[cfg(feature = "graphics")]
 pub type Display3in7 = crate::graphics::Display<
@@ -42,7 +44,7 @@ pub type Display3in7 = crate::graphics::Display<
 /// EPD3in7 driver
 pub struct EPD3in7<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Background Color
     background_color: Color,
 }

--- a/src/epd4in2/mod.rs
+++ b/src/epd4in2/mod.rs
@@ -68,6 +68,7 @@ pub const HEIGHT: u32 = 300;
 /// Default Background Color
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = true;
+const SINGLE_BYTE_WRITE: bool = true;
 
 use crate::color::Color;
 
@@ -89,7 +90,7 @@ pub type Display4in2 = crate::graphics::Display<
 ///
 pub struct Epd4in2<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Background Color
     color: Color,
     /// Refresh LUT

--- a/src/epd5in65f/mod.rs
+++ b/src/epd5in65f/mod.rs
@@ -35,12 +35,14 @@ pub const WIDTH: u32 = 600;
 pub const HEIGHT: u32 = 448;
 /// Default Background Color
 pub const DEFAULT_BACKGROUND_COLOR: OctColor = OctColor::White;
+/// Default mode of writing data (single byte vs blockwise)
+const SINGLE_BYTE_WRITE: bool = true;
 
 /// Epd5in65f driver
 ///
 pub struct Epd5in65f<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Background Color
     color: OctColor,
 }

--- a/src/epd5in83b_v2/mod.rs
+++ b/src/epd5in83b_v2/mod.rs
@@ -38,12 +38,13 @@ pub const HEIGHT: u32 = 480;
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = true;
 const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
+const SINGLE_BYTE_WRITE: bool = true;
 
 /// Epd7in5 driver
 ///
 pub struct Epd5in83<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Background Color
     color: Color,
 }

--- a/src/epd7in5/mod.rs
+++ b/src/epd7in5/mod.rs
@@ -36,12 +36,13 @@ pub const HEIGHT: u32 = 384;
 /// Default Background Color
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = true;
+const SINGLE_BYTE_WRITE: bool = false;
 
 /// Epd7in5 driver
 ///
 pub struct Epd7in5<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Background Color
     color: Color,
 }

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -39,12 +39,13 @@ pub const HEIGHT: u32 = 528;
 /// Default Background Color
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White; // Inverted for HD as compared to 7in5 v2 (HD: 0xFF = White)
 const IS_BUSY_LOW: bool = false;
+const SINGLE_BYTE_WRITE: bool = false;
 
 /// EPD7in5 (HD) driver
 ///
 pub struct Epd7in5<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Background Color
     color: Color,
 }

--- a/src/epd7in5_v2/mod.rs
+++ b/src/epd7in5_v2/mod.rs
@@ -40,12 +40,13 @@ pub const HEIGHT: u32 = 480;
 /// Default Background Color
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = true;
+const SINGLE_BYTE_WRITE: bool = false;
 
 /// Epd7in5 (V2) driver
 ///
 pub struct Epd7in5<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Background Color
     color: Color,
 }

--- a/src/epd7in5_v3/mod.rs
+++ b/src/epd7in5_v3/mod.rs
@@ -44,12 +44,13 @@ pub const DEFAULT_BACKGROUND_COLOR: TriColor = TriColor::White;
 /// Number of bits for b/w buffer and same for chromatic buffer
 const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
 const IS_BUSY_LOW: bool = true;
+const SINGLE_BYTE_WRITE: bool = false;
 
 /// Epd7in5 (V3) driver
 ///
 pub struct Epd7in5<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Background Color
     color: TriColor,
 }

--- a/src/epd7in5b_v2/mod.rs
+++ b/src/epd7in5b_v2/mod.rs
@@ -42,12 +42,13 @@ pub const DEFAULT_BACKGROUND_COLOR: TriColor = TriColor::White;
 
 const NUM_DISPLAY_BYTES: usize = WIDTH as usize * HEIGHT as usize / 8;
 const IS_BUSY_LOW: bool = true;
+const SINGLE_BYTE_WRITE: bool = false;
 
 /// Epd7in5 (V2) driver
 ///
 pub struct Epd7in5<SPI, CS, BUSY, DC, RST, DELAY> {
     /// Connection Interface
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
     /// Background Color
     color: TriColor,
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -7,6 +7,8 @@ use embedded_hal::{
 
 /// The Connection Interface of all (?) Waveshare EPD-Devices
 ///
+/// SINGLE_BYTE_WRITE defines if a data block is written bytewise
+/// or blockwise to the spi device
 pub(crate) struct DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, const SINGLE_BYTE_WRITE: bool> {
     /// SPI
     _spi: PhantomData<SPI>,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -7,7 +7,7 @@ use embedded_hal::{
 
 /// The Connection Interface of all (?) Waveshare EPD-Devices
 ///
-pub(crate) struct DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY> {
+pub(crate) struct DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, const SINGLE_BYTE_WRITE: bool> {
     /// SPI
     _spi: PhantomData<SPI>,
     /// DELAY
@@ -24,7 +24,8 @@ pub(crate) struct DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY> {
     delay_us: u32,
 }
 
-impl<SPI, CS, BUSY, DC, RST, DELAY> DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>
+impl<SPI, CS, BUSY, DC, RST, DELAY, const SINGLE_BYTE_WRITE: bool>
+    DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>
 where
     SPI: Write<u8>,
     CS: OutputPin,
@@ -68,9 +69,13 @@ where
         // high for data
         let _ = self.dc.set_high();
 
-        for val in data.iter().copied() {
-            // Transfer data one u8 at a time over spi
-            self.write(spi, &[val])?;
+        if SINGLE_BYTE_WRITE {
+            for val in data.iter().copied() {
+                // Transfer data one u8 at a time over spi
+                self.write(spi, &[val])?;
+            }
+        } else {
+            self.write(spi, data)?;
         }
 
         Ok(())


### PR DESCRIPTION
This pr adds a possible fix for a bug introduced  in #83 and discussed in #70.
A switch case is added to let each epd decide if it wants to write its data blockwise or bytewise over spi.

I wasn't able to test this myself.

Closes #142.