### PR TITLE
Fixed init code for epd1in54_vs

### DIFF
--- a/src/epd1in54_v2/mod.rs
+++ b/src/epd1in54_v2/mod.rs
@@ -71,9 +71,6 @@ where
 
         self.set_ram_area(spi, delay, 0, 0, WIDTH - 1, HEIGHT - 1)?;
 
-        self.interface
-            .cmd_with_data(spi, Command::BorderWaveformControl, &[0x1])?;
-
         self.interface.cmd_with_data(
             spi,
             Command::TemperatureSensorSelection,
@@ -84,6 +81,9 @@ where
             .cmd_with_data(spi, Command::TemperatureSensorControl, &[0xB1, 0x20])?;
 
         self.set_ram_counter(spi, delay, 0, 0)?;
+
+        //Initialize the lookup table with a refresh waveform
+        self.set_lut(spi, delay, None)?;
 
         self.wait_until_idle(spi, delay)?;
         Ok(())


### PR DESCRIPTION
Added loading of look-up-table to init for 1in54_v2. Closes #154 .