### PR TITLE
Adds support for the Waveshare 5.83" E-Ink Display

### DIFF
--- a/src/epd5in83_v2/command.rs
+++ b/src/epd5in83_v2/command.rs
@@ -1,0 +1,134 @@
+//! SPI Commands for the Waveshare 5.83" E-Ink Display
+
+use crate::traits;
+
+/// Epd5in83 commands
+///
+/// Should rarely (never?) be needed directly.
+///
+/// For more infos about the addresses and what they are doing look into the PDFs.
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub(crate) enum Command {
+    /// Set Resolution, LUT selection, BWR pixels, gate scan direction, source shift
+    /// direction, booster switch, soft reset.
+    PanelSetting = 0x00,
+
+    /// Selecting internal and external power
+    PowerSetting = 0x01,
+
+    /// After the Power Off command, the driver will power off following the Power Off
+    /// Sequence; BUSY signal will become "0". This command will turn off charge pump,
+    /// T-con, source driver, gate driver, VCOM, and temperature sensor, but register
+    /// data will be kept until VDD becomes OFF. Source Driver output and Vcom will remain
+    /// as previous condition, which may have 2 conditions: 0V or floating.
+    PowerOff = 0x02,
+
+    /// Setting Power OFF sequence
+    PowerOffSequenceSetting = 0x03,
+
+    /// Turning On the Power
+    ///
+    /// After the Power ON command, the driver will power on following the Power ON
+    /// sequence. Once complete, the BUSY signal will become "1".
+    PowerOn = 0x04,
+
+    /// Starting data transmission
+    BoosterSoftStart = 0x06,
+
+    /// This command makes the chip enter the deep-sleep mode to save power.
+    ///
+    /// The deep sleep mode would return to stand-by by hardware reset.
+    ///
+    /// The only one parameter is a check code, the command would be excuted if check code = 0xA5.
+    DeepSleep = 0x07,
+
+    /// This command starts transmitting B/W data and write them into SRAM. To complete data
+    /// transmission, commands Display Refresh or Data Start Transmission2 must be issued. Then the chip will start to
+    /// send data/VCOM for panel.
+    DataStartTransmission1 = 0x10,
+
+    /// This command starts transmitting RED data and write them into SRAM. To complete data
+    /// transmission, command Display refresh must be issued. Then the chip will start to
+    /// send data/VCOM for panel.
+    DataStartTransmission2 = 0x13,
+
+    /// To stop data transmission, this command must be issued to check the `data_flag`.
+    ///
+    /// After this command, BUSY signal will become "0" until the display update is
+    /// finished.
+    DataStop = 0x11,
+
+    /// After this command is issued, driver will refresh display (data/VCOM) according to
+    /// SRAM data and LUT.
+    ///
+    /// After Display Refresh command, BUSY signal will become "0" until the display
+    /// update is finished.
+    DisplayRefresh = 0x12,
+
+    /// Enables or disables Dual SPI mode
+    DualSPI = 0x15,
+
+    /// The command controls the PLL clock frequency.
+    PllControl = 0x30,
+
+    /// This command reads the temperature sensed by the temperature sensor.
+    TemperatureSensorCalibration = 0x40,
+    /// This command selects the Internal or External temperature sensor.
+    TemperatureSensorSelection = 0x41,
+    /// This command could write data to the external temperature sensor.
+    TemperatureSensorWrite = 0x42,
+    /// This command could read data from the external temperature sensor.
+    TemperatureSensorRead = 0x43,
+
+    /// This command indicates the interval of Vcom and data output. When setting the
+    /// vertical back porch, the total blanking will be kept (20 Hsync).
+    VcomAndDataIntervalSetting = 0x50,
+    /// This command indicates the input power condition. Host can read this flag to learn
+    /// the battery condition.
+    LowPowerDetection = 0x51,
+
+    /// This command defines non-overlap period of Gate and Source.
+    TconSetting = 0x60,
+    /// This command defines alternative resolution and this setting is of higher priority
+    /// than the RES\[1:0\] in R00H (PSR).
+    TconResolution = 0x61,
+
+    /// The LUT_REV / Chip Revision is read from OTP address = 25001 and 25000.
+    Revision = 0x70,
+    /// This command reads the IC status.
+    GetStatus = 0x71,
+
+    /// This command implements related VCOM sensing setting.
+    AutoMeasurementVcom = 0x80,
+    /// This command gets the VCOM value.
+    ReadVcomValue = 0x81,
+    /// This command sets `VCOM_DC` value.
+    VcmDcSetting = 0x82,
+
+    /// Sets window size for the partial update
+    PartialWindow = 0x90,
+    /// Sets chip into partial update mode
+    PartialIn = 0x91,
+    /// Quits partial update mode
+    PartialOut = 0x92,
+}
+
+impl traits::Command for Command {
+    /// Returns the address of the command
+    fn address(self) -> u8 {
+        self as u8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::traits::Command as CommandTrait;
+
+    #[test]
+    fn command_addr() {
+        assert_eq!(Command::PanelSetting.address(), 0x00);
+        assert_eq!(Command::DisplayRefresh.address(), 0x12);
+    }
+}

--- a/src/epd5in83_v2/mod.rs
+++ b/src/epd5in83_v2/mod.rs
@@ -1,0 +1,274 @@
+//! A simple Driver for the Waveshare 5.83" v2 E-Ink Display via SPI
+//!
+//! # References
+//!
+//! - [Datasheet](https://www.waveshare.com/5.83inch-e-paper-hat.htm)
+//! - [Waveshare C driver](https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_5in83_V2.c)
+//! - [Waveshare Python driver](https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/python/lib/waveshare_epd/epd5in83_V2.py)
+
+use embedded_hal::{
+    blocking::{delay::*, spi::Write},
+    digital::v2::{InputPin, OutputPin},
+};
+
+use crate::color::Color;
+use crate::interface::DisplayInterface;
+use crate::prelude::WaveshareDisplay;
+use crate::traits::{InternalWiAdditions, RefreshLut};
+
+pub(crate) mod command;
+use self::command::Command;
+use crate::buffer_len;
+
+/// Full size buffer for use with the 5in83 v2 EPD
+#[cfg(feature = "graphics")]
+pub type Display5in83 = crate::graphics::Display<
+    WIDTH,
+    HEIGHT,
+    false,
+    { buffer_len(WIDTH as usize, HEIGHT as usize) },
+    Color,
+>;
+
+/// Width of the display
+pub const WIDTH: u32 = 648;
+/// Height of the display
+pub const HEIGHT: u32 = 480;
+/// Default Background Color
+pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
+const IS_BUSY_LOW: bool = true;
+const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
+
+/// Epd5in83 driver
+///
+pub struct Epd5in83<SPI, CS, BUSY, DC, RST, DELAY> {
+    /// Connection Interface
+    interface: DisplayInterface<SPI, CS, BUSY, DC, RST, DELAY>,
+    /// Background Color
+    color: Color,
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> InternalWiAdditions<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd5in83<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayUs<u32>,
+{
+    fn init(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        // Reset the device
+        self.interface.reset(delay, 2000, 50);
+
+        // Set the power settings: VGH=20V,VGL=-20V,VDH=15V,VDL=-15V
+        self.cmd_with_data(spi, Command::PowerSetting, &[0x07, 0x07, 0x3F, 0x3F])?;
+
+        // Power on
+        self.command(spi, Command::PowerOn)?;
+        delay.delay_us(5000);
+        self.wait_until_idle(spi, delay)?;
+
+        // Set the panel settings: BWOTP
+        self.cmd_with_data(spi, Command::PanelSetting, &[0x1F])?;
+
+        // Set the real resolution
+        self.send_resolution(spi)?;
+
+        // Disable dual SPI
+        self.cmd_with_data(spi, Command::DualSPI, &[0x00])?;
+
+        // Set Vcom and data interval
+        self.cmd_with_data(spi, Command::VcomAndDataIntervalSetting, &[0x10, 0x07])?;
+
+        // Set S2G and G2S non-overlap periods to 12 (default)
+        self.cmd_with_data(spi, Command::TconSetting, &[0x22])?;
+
+        self.wait_until_idle(spi, delay)?;
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> WaveshareDisplay<SPI, CS, BUSY, DC, RST, DELAY>
+    for Epd5in83<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayUs<u32>,
+{
+    type DisplayColor = Color;
+    fn new(
+        spi: &mut SPI,
+        cs: CS,
+        busy: BUSY,
+        dc: DC,
+        rst: RST,
+        delay: &mut DELAY,
+        delay_us: Option<u32>,
+    ) -> Result<Self, SPI::Error> {
+        let interface = DisplayInterface::new(cs, busy, dc, rst, delay_us);
+        let color = DEFAULT_BACKGROUND_COLOR;
+
+        let mut epd = Epd5in83 { interface, color };
+
+        epd.init(spi, delay)?;
+
+        Ok(epd)
+    }
+
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
+        self.command(spi, Command::PowerOff)?;
+        self.wait_until_idle(spi, delay)?;
+        self.cmd_with_data(spi, Command::DeepSleep, &[0xA5])?;
+        Ok(())
+    }
+
+    fn wake_up(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.init(spi, delay)
+    }
+
+    fn set_background_color(&mut self, color: Color) {
+        self.color = color;
+    }
+
+    fn background_color(&self) -> &Color {
+        &self.color
+    }
+
+    fn width(&self) -> u32 {
+        WIDTH
+    }
+
+    fn height(&self) -> u32 {
+        HEIGHT
+    }
+
+    fn update_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
+        let color_value = self.color.get_byte_value();
+
+        self.interface.cmd(spi, Command::DataStartTransmission1)?;
+        self.interface
+            .data_x_times(spi, color_value, WIDTH / 8 * HEIGHT)?;
+
+        self.interface
+            .cmd_with_data(spi, Command::DataStartTransmission2, buffer)?;
+        Ok(())
+    }
+
+    fn update_partial_frame(
+        &mut self,
+        _spi: &mut SPI,
+        _delay: &mut DELAY,
+        _buffer: &[u8],
+        _x: u32,
+        _y: u32,
+        _width: u32,
+        _height: u32,
+    ) -> Result<(), SPI::Error> {
+        unimplemented!()
+    }
+
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.command(spi, Command::DisplayRefresh)?;
+        self.wait_until_idle(spi, delay)?;
+        Ok(())
+    }
+
+    fn update_and_display_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.update_frame(spi, buffer, delay)?;
+        self.display_frame(spi, delay)?;
+        Ok(())
+    }
+
+    fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.wait_until_idle(spi, delay)?;
+
+        self.command(spi, Command::DataStartTransmission1)?;
+        self.interface.data_x_times(spi, 0xFF, NUM_DISPLAY_BITS)?;
+
+        self.command(spi, Command::DataStartTransmission2)?;
+        self.interface.data_x_times(spi, 0x00, NUM_DISPLAY_BITS)?;
+
+        Ok(())
+    }
+
+    fn set_lut(
+        &mut self,
+        _spi: &mut SPI,
+        _delay: &mut DELAY,
+        _refresh_rate: Option<RefreshLut>,
+    ) -> Result<(), SPI::Error> {
+        unimplemented!();
+    }
+
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
+    }
+}
+
+impl<SPI, CS, BUSY, DC, RST, DELAY> Epd5in83<SPI, CS, BUSY, DC, RST, DELAY>
+where
+    SPI: Write<u8>,
+    CS: OutputPin,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayUs<u32>,
+{
+    fn command(&mut self, spi: &mut SPI, command: Command) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, command)
+    }
+
+    fn send_data(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
+        self.interface.data(spi, data)
+    }
+
+    fn cmd_with_data(
+        &mut self,
+        spi: &mut SPI,
+        command: Command,
+        data: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd_with_data(spi, command, data)
+    }
+
+    fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        let w = self.width();
+        let h = self.height();
+
+        self.command(spi, Command::TconResolution)?;
+        self.send_data(spi, &[(w >> 8) as u8])?;
+        self.send_data(spi, &[w as u8])?;
+        self.send_data(spi, &[(h >> 8) as u8])?;
+        self.send_data(spi, &[h as u8])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epd_size() {
+        assert_eq!(WIDTH, 648);
+        assert_eq!(HEIGHT, 480);
+        assert_eq!(DEFAULT_BACKGROUND_COLOR, Color::White);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub mod epd2in9bc;
 pub mod epd3in7;
 pub mod epd4in2;
 pub mod epd5in65f;
+pub mod epd5in83_v2;
 pub mod epd5in83b_v2;
 pub mod epd7in5;
 pub mod epd7in5_hd;


### PR DESCRIPTION
This module is for this display: https://www.waveshare.com/5.83inch-e-paper.htm
Based on the C library here: https://github.com/waveshare/e-Paper/blob/master/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_5in83_V2.c

I have written this module since I own this particular display. I kept the partial update out since, from what I can understand, it is not supported on it: https://www.waveshare.com/5.83inch-e-paper.htm (See selection guide)

I can confirm it works on a real hardware test :)

The code itself is fairly similar to other B/W displays, I didn't have to do much other than fixing some operation codes during init.