### PR TITLE
Update 'B' 1.54" e-ink display, and remove 'C' display link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ epd.update_and_display_frame( & mut spi, & display.buffer()) ?;
 | [2.9 Inch B/W (A)](https://www.waveshare.com/product/2.9inch-e-paper-module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 | [2.9 Inch B/W V2 (A)](https://www.waveshare.com/product/2.9inch-e-paper-module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 | [2.7 Inch 3 Color (B)](https://www.waveshare.com/2.7inch-e-paper-b.htm) | Black, White, Red | ✕ | ✔ | ✔ | ✔ |
-| [1.54 Inch B/W/R (B)](https://www.waveshare.com/product/modules/oleds-lcds/e-paper/1.54inch-e-paper-module-b.htm) | Black, White, Red | ✕ | ✕ | ✔ | ✔ |
-| [1.54 Inch B/W/Y (C)](https://www.waveshare.com/1.54inch-e-paper-c.htm) | Black, White, Yellow | ✕ | ✕ | ✔ | ✔ |
+| [1.54 Inch B/W/R (B)](https://www.waveshare.com/1.54inch-e-Paper-B.htm) | Black, White, Red | ✕ | ✕ | ✔ | ✔ |
+| 1.54 Inch B/W/Y (C) - no longer available | Black, White, Yellow | ✕ | ✕ | ✔ | ✔ |
 | [1.54 Inch B/W (A)](https://www.waveshare.com/1.54inch-e-Paper-Module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 
 ### [1]: 7.5 Inch B/W V2 (A)


### PR DESCRIPTION
The 1.54" B/W/R (B) e-ink display URI has changed. However, the 1.54" B/W/Y (C) e-ink display is no longer available.

Resolves #161.