### PR TITLE
Re-add discontinued fixed link for 1.54" 'C' display

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ epd.update_and_display_frame( & mut spi, & display.buffer()) ?;
 | [2.9 Inch B/W (A)](https://www.waveshare.com/product/2.9inch-e-paper-module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 | [2.9 Inch B/W V2 (A)](https://www.waveshare.com/product/2.9inch-e-paper-module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 | [2.7 Inch 3 Color (B)](https://www.waveshare.com/2.7inch-e-paper-b.htm) | Black, White, Red | ✕ | ✔ | ✔ | ✔ |
+| [1.54 Inch B/W/Y (C) (Discontinued)](https://www.waveshare.com/1.54inch-e-paper-module-c.htm) | Black, White, Yellow | ✕ | ✕ | ✔ | ✔ |
 | [1.54 Inch B/W/R (B)](https://www.waveshare.com/1.54inch-e-Paper-B.htm) | Black, White, Red | ✕ | ✕ | ✔ | ✔ |
-| 1.54 Inch B/W/Y (C) - no longer available | Black, White, Yellow | ✕ | ✕ | ✔ | ✔ |
 | [1.54 Inch B/W (A)](https://www.waveshare.com/1.54inch-e-Paper-Module.htm) | Black, White | ✕ | ✔ | ✔ | ✔ |
 
 ### [1]: 7.5 Inch B/W V2 (A)


### PR DESCRIPTION
Related to 6948a63.

I reached out to Waveshare, who provided a working link, but advised the
module is now discontinued.

This PR re-adds the link, but notes it is discontinued.

See also: #161.
