### PR TITLE
Fix Examples

### DIFF
--- a/examples/epd1in54_no_graphics.rs
+++ b/examples/epd1in54_no_graphics.rs
@@ -5,7 +5,7 @@ use epd_waveshare::{epd1in54::Epd1in54, prelude::*};
 use linux_embedded_hal::{
     spidev::{self, SpidevOptions},
     sysfs_gpio::Direction,
-    Delay, SPIError, Spidev, SysfsPin,
+    Delay, SPIError, SpidevDevice, SysfsPin,
 };
 
 // activate spi, gpio in raspi-config
@@ -15,7 +15,7 @@ use linux_embedded_hal::{
 fn main() -> Result<(), SPIError> {
     // Configure SPI
     // SPI settings are from eink-waveshare-rs documenation
-    let mut spi = Spidev::open("/dev/spidev0.0")?;
+    let mut spi = SpidevDevice::open("/dev/spidev0.0")?;
     let options = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(4_000_000)

--- a/examples/epd2in13_v2.rs
+++ b/examples/epd2in13_v2.rs
@@ -16,7 +16,7 @@ use epd_waveshare::{
 use linux_embedded_hal::{
     spidev::{self, SpidevOptions},
     sysfs_gpio::Direction,
-    Delay, SPIError, Spidev, SysfsPin,
+    Delay, SPIError, SpidevDevice, SysfsPin,
 };
 
 // The pins in this example are for the Universal e-Paper Raw Panel Driver HAT
@@ -27,7 +27,7 @@ use linux_embedded_hal::{
 fn main() -> Result<(), SPIError> {
     // Configure SPI
     // Settings are taken from
-    let mut spi = Spidev::open("/dev/spidev0.0").expect("spidev directory");
+    let mut spi = SpidevDevice::open("/dev/spidev0.0").expect("spidev directory");
     let options = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(4_000_000)

--- a/examples/epd2in13bc.rs
+++ b/examples/epd2in13bc.rs
@@ -16,7 +16,7 @@ use epd_waveshare::{
 use linux_embedded_hal::{
     spidev::{self, SpidevOptions},
     sysfs_gpio::Direction,
-    Delay, SPIError, Spidev, SysfsPin,
+    Delay, SPIError, SpidevDevice, SysfsPin,
 };
 
 // activate spi, gpio in raspi-config
@@ -61,7 +61,7 @@ fn main() -> Result<(), SPIError> {
 
     // Configure SPI
     // Settings are taken from
-    let mut spi = Spidev::open("/dev/spidev0.0").expect("spidev directory");
+    let mut spi = SpidevDevice::open("/dev/spidev0.0").expect("spidev directory");
     let options = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(10_000_000)

--- a/examples/epd4in2.rs
+++ b/examples/epd4in2.rs
@@ -16,7 +16,7 @@ use epd_waveshare::{
 use linux_embedded_hal::{
     spidev::{self, SpidevOptions},
     sysfs_gpio::Direction,
-    Delay, SPIError, Spidev, SysfsPin,
+    Delay, SPIError, SpidevDevice, SysfsPin,
 };
 
 // activate spi, gpio in raspi-config
@@ -26,7 +26,7 @@ use linux_embedded_hal::{
 fn main() -> Result<(), SPIError> {
     // Configure SPI
     // Settings are taken from
-    let mut spi = Spidev::open("/dev/spidev0.0").expect("spidev directory");
+    let mut spi = SpidevDevice::open("/dev/spidev0.0").expect("spidev directory");
     let options = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(4_000_000)

--- a/examples/epd4in2_variable_size.rs
+++ b/examples/epd4in2_variable_size.rs
@@ -17,7 +17,7 @@ use epd_waveshare::{
 use linux_embedded_hal::{
     spidev::{self, SpidevOptions},
     sysfs_gpio::Direction,
-    Delay, SPIError, Spidev, SysfsPin,
+    Delay, SPIError, SpidevDevice, SysfsPin,
 };
 
 // activate spi, gpio in raspi-config
@@ -27,7 +27,7 @@ use linux_embedded_hal::{
 fn main() -> Result<(), SPIError> {
     // Configure SPI
     // Settings are taken from
-    let mut spi = Spidev::open("/dev/spidev0.0").expect("spidev directory");
+    let mut spi = SpidevDevice::open("/dev/spidev0.0").expect("spidev directory");
     let options = SpidevOptions::new()
         .bits_per_word(8)
         .max_speed_hz(4_000_000)


### PR DESCRIPTION
So the underlying linux-embedded-hal renamed Spidev to SpidevDevice. Sensical change, but the examples needed to be updated to match that change.

I've only tested that the examples build again, I don't have easy access to hardware to test the results on right now