### PR TITLE
fix: overflow error for all displays

### DIFF
--- a/src/epd1in54b/mod.rs
+++ b/src/epd1in54b/mod.rs
@@ -279,12 +279,12 @@ where
 
         // Uses 2 bits per pixel
         self.interface
-            .data_x_times(spi, color, 2 * (WIDTH * HEIGHT / 8))?;
+            .data_x_times(spi, color, 2 * (WIDTH / 8 * HEIGHT))?;
 
         // Clear the red
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
         self.interface
-            .data_x_times(spi, color, WIDTH * HEIGHT / 8)?;
+            .data_x_times(spi, color, WIDTH / 8 * HEIGHT)?;
         Ok(())
     }
 

--- a/src/epd1in54c/mod.rs
+++ b/src/epd1in54c/mod.rs
@@ -14,7 +14,7 @@ pub const HEIGHT: u32 = 152;
 /// Default Background Color (white)
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = true;
-const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
+const NUM_DISPLAY_BITS: u32 = WIDTH / 8 * HEIGHT;
 const SINGLE_BYTE_WRITE: bool = true;
 
 use crate::color::Color;

--- a/src/epd2in13bc/mod.rs
+++ b/src/epd2in13bc/mod.rs
@@ -65,7 +65,7 @@ pub const HEIGHT: u32 = 212;
 pub const DEFAULT_BACKGROUND_COLOR: TriColor = TriColor::White;
 
 /// Number of bits for b/w buffer and same for chromatic buffer
-const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
+const NUM_DISPLAY_BITS: u32 = WIDTH / 8 * HEIGHT;
 
 const IS_BUSY_LOW: bool = true;
 const VCOM_DATA_INTERVAL: u8 = 0x07;

--- a/src/epd2in7b/mod.rs
+++ b/src/epd2in7b/mod.rs
@@ -168,7 +168,7 @@ where
         // Clear chromatic layer since we won't be using it here
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
         self.interface
-            .data_x_times(spi, !self.color.get_byte_value(), WIDTH * HEIGHT / 8)?;
+            .data_x_times(spi, !self.color.get_byte_value(), WIDTH / 8 * HEIGHT)?;
 
         self.interface.cmd(spi, Command::DataStop)?;
         Ok(())
@@ -225,13 +225,13 @@ where
         let color_value = self.color.get_byte_value();
         self.interface.cmd(spi, Command::DataStartTransmission1)?;
         self.interface
-            .data_x_times(spi, color_value, WIDTH * HEIGHT / 8)?;
+            .data_x_times(spi, color_value, WIDTH / 8 * HEIGHT)?;
 
         self.interface.cmd(spi, Command::DataStop)?;
 
         self.interface.cmd(spi, Command::DataStartTransmission2)?;
         self.interface
-            .data_x_times(spi, color_value, WIDTH * HEIGHT / 8)?;
+            .data_x_times(spi, color_value, WIDTH / 8 * HEIGHT)?;
         self.interface.cmd(spi, Command::DataStop)?;
         Ok(())
     }

--- a/src/epd2in9bc/mod.rs
+++ b/src/epd2in9bc/mod.rs
@@ -68,7 +68,7 @@ pub const HEIGHT: u32 = 296;
 /// Default background color (white) of epd2in9bc display
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 
-const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
+const NUM_DISPLAY_BITS: u32 = WIDTH / 8 * HEIGHT;
 
 const IS_BUSY_LOW: bool = true;
 const VCOM_DATA_INTERVAL: u8 = 0x07;

--- a/src/epd5in83b_v2/mod.rs
+++ b/src/epd5in83b_v2/mod.rs
@@ -38,7 +38,7 @@ pub const HEIGHT: u32 = 480;
 /// Default Background Color
 pub const DEFAULT_BACKGROUND_COLOR: Color = Color::White;
 const IS_BUSY_LOW: bool = true;
-const NUM_DISPLAY_BITS: u32 = WIDTH * HEIGHT / 8;
+const NUM_DISPLAY_BITS: u32 = WIDTH / 8 * HEIGHT;
 const SINGLE_BYTE_WRITE: bool = true;
 
 /// Epd7in5 driver

--- a/src/epd7in5_hd/mod.rs
+++ b/src/epd7in5_hd/mod.rs
@@ -185,7 +185,7 @@ where
     }
 
     fn clear_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
-        let pixel_count = WIDTH * HEIGHT / 8;
+        let pixel_count = WIDTH / 8 * HEIGHT;
         let background_color_byte = self.color.get_byte_value();
 
         self.wait_until_idle(spi, delay)?;

--- a/src/epd7in5_v2/mod.rs
+++ b/src/epd7in5_v2/mod.rs
@@ -171,10 +171,10 @@ where
         self.send_resolution(spi)?;
 
         self.command(spi, Command::DataStartTransmission1)?;
-        self.interface.data_x_times(spi, 0x00, WIDTH * HEIGHT / 8)?;
+        self.interface.data_x_times(spi, 0x00, WIDTH / 8 * HEIGHT)?;
 
         self.command(spi, Command::DataStartTransmission2)?;
-        self.interface.data_x_times(spi, 0x00, WIDTH * HEIGHT / 8)?;
+        self.interface.data_x_times(spi, 0x00, WIDTH / 8 * HEIGHT)?;
 
         self.command(spi, Command::DisplayRefresh)?;
         Ok(())

--- a/src/epd7in5b_v2/mod.rs
+++ b/src/epd7in5b_v2/mod.rs
@@ -256,10 +256,10 @@ where
         self.send_resolution(spi)?;
 
         self.command(spi, Command::DataStartTransmission1)?;
-        self.interface.data_x_times(spi, 0xFF, WIDTH * HEIGHT / 8)?;
+        self.interface.data_x_times(spi, 0xFF, WIDTH / 8 * HEIGHT)?;
 
         self.command(spi, Command::DataStartTransmission2)?;
-        self.interface.data_x_times(spi, 0x00, WIDTH * HEIGHT / 8)?;
+        self.interface.data_x_times(spi, 0x00, WIDTH / 8 * HEIGHT)?;
 
         self.interface.cmd(spi, Command::DataStop)?;
 


### PR DESCRIPTION
Changes all occurrences of `WIDTH * HEIGHT / 8` to `WIDTH / 8 * HEIGHT`.
This was already applied for `epd7in5b_v2` in #173.

Original issue: #151
