### PR TITLE
fix: color bitmask calculation

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -124,7 +124,7 @@ impl ColorType for OctColor {
     const BITS_PER_PIXEL_PER_BUFFER: usize = 4;
     const BUFFER_COUNT: usize = 1;
     fn bitmask(&self, _bwrbit: bool, pos: u32) -> (u8, u16) {
-        let mask = !(0xF0 >> (pos % 2));
+        let mask = !(0xF0 >> (pos % 2) * 4);
         let bits = self.get_nibble() as u16;
         (mask, if pos % 2 == 1 { bits } else { bits << 4 })
     }


### PR DESCRIPTION
**Consider the following code: `let mask = !(0xF0 >> (pos % 2));`**

In this code, `0xF0` represents the binary value `0b11110000`. When `pos` is even, `(pos % 2)` equals `0`. Therefore, the right shift operation on `0b11110000` by `0` does not change the value, resulting in `mask = 0b00001111`.
However, when `pos` is odd, `(pos % 2)` equals `1`. In this case, the right shift operation on `0b11110000` by `1` results in `0b01111000`, which is incorrect.

**To fix this issue, modify the code to `let mask = !(0xF0 >> (pos % 2) * 4);`.**

With this modification, when `pos` is even, `(pos % 2)` equals `0`, and the right shift operation by `0 * 4 = 0` does not change the value, resulting in `mask = 0b00001111`.

Similarly, when `pos` is odd, `(pos % 2)` equals `1`, and the right shift operation by `1 * 4 = 4` correctly results in `0b00001111`, giving `mask = 0b11110000`.