### PR TITLE
Add support for EPD 2.13" (b) V4

### DIFF
--- a/src/epd2in13b_v4/command.rs
+++ b/src/epd2in13b_v4/command.rs
@@ -1,0 +1,27 @@
+//! SPI Commands for the Waveshare 2.13" (B/C) E-Ink Display
+use crate::traits;
+
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
+pub(crate) enum Command {
+    DriverOutputControl = 0x01,
+    DeepSleepMode = 0x10,
+    DataEntryModeSetting = 0x11,
+    SwReset = 0x12,
+    MasterActivation = 0x20,
+    DisplayUpdateControl = 0x21,
+    WriteRamBlackWhite = 0x24,
+    WriteRamRed = 0x26,
+    SelectBorderWaveform = 0x3C,
+    SetRamXAddressStartEndPosition = 0x44,
+    SetRamYAddressStartEndPosition = 0x45,
+    SetRamXAddressCounter = 0x4E,
+    SetRamYAddressCounter = 0x4F,
+}
+
+impl traits::Command for Command {
+    /// Returns the address of the command
+    fn address(self) -> u8 {
+        self as u8
+    }
+}

--- a/src/epd2in13b_v4/mod.rs
+++ b/src/epd2in13b_v4/mod.rs
@@ -1,0 +1,425 @@
+//! A simple Driver for the Waveshare 2.13" (B/C) E-Ink Display via SPI
+//! More information on this display can be found at the [Waveshare Wiki](https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT_(B))
+//! This driver was build and tested for 212x104, 2.13inch E-Ink display HAT for Raspberry Pi, three-color, SPI interface
+//!
+//! # Example for the 2.13" E-Ink Display
+//!
+//!```rust, no_run
+//!# use embedded_hal_mock::eh1::*;
+//!# fn main() -> Result<(), embedded_hal::spi::ErrorKind> {
+//!use embedded_graphics::{prelude::*, primitives::{Line, PrimitiveStyle, PrimitiveStyleBuilder}};
+//!use epd_waveshare::{epd2in13bV4::*, prelude::*};
+//!#
+//!# let expectations = [];
+//!# let mut spi = spi::Mock::new(&expectations);
+//!# let expectations = [];
+//!# let cs_pin = pin::Mock::new(&expectations);
+//!# let busy_in = pin::Mock::new(&expectations);
+//!# let dc = pin::Mock::new(&expectations);
+//!# let rst = pin::Mock::new(&expectations);
+//!# let mut delay = delay::NoopDelay::new();
+//!
+//!// Setup EPD
+//!let mut epd = Epd2in13bV4::new(&mut spi, busy_in, dc, rst, &mut delay, None)?;
+//!
+//!// Use display graphics from embedded-graphics
+//!// This display is for the black/white/chromatic pixels
+//!let mut tricolor_display = Display2in13bV4::default();
+//!
+//!// Use embedded graphics for drawing a black line
+//!let _ = Line::new(Point::new(0, 120), Point::new(0, 200))
+//!    .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 1))
+//!    .draw(&mut tricolor_display);
+//!
+//!// We use `chromatic` but it will be shown as red/yellow
+//!let _ = Line::new(Point::new(15, 120), Point::new(15, 200))
+//!    .into_styled(PrimitiveStyle::with_stroke(TriColor::Chromatic, 1))
+//!    .draw(&mut tricolor_display);
+//!
+//!// Display updated frame
+//!epd.update_color_frame(
+//!    &mut spi,
+//!    &mut delay,
+//!    &tricolor_display.bw_buffer(),
+//!    &tricolor_display.chromatic_buffer()
+//!)?;
+//!epd.display_frame(&mut spi, &mut delay)?;
+//!
+//!// Set the EPD to sleep
+//!epd.sleep(&mut spi, &mut delay)?;
+//!# Ok(())
+//!# }
+//!```
+use embedded_hal::{delay::*, digital::*, spi::SpiDevice};
+
+use crate::interface::DisplayInterface;
+use crate::traits::{
+    InternalWiAdditions, RefreshLut, WaveshareDisplay, WaveshareThreeColorDisplay,
+};
+
+/// Width of epd2in13bV4 in pixels
+pub const WIDTH: u32 = 122;
+/// Height of epd2in13bV4 in pixels
+pub const HEIGHT: u32 = 250;
+/// Default background color (white) of epd2in13bV4 display
+pub const DEFAULT_BACKGROUND_COLOR: TriColor = TriColor::White;
+
+/// Number of bits for b/w buffer and same for chromatic buffer
+const NUM_DISPLAY_BYTES: u32 = (WIDTH + 7) / 8 * HEIGHT;
+
+const IS_BUSY_LOW: bool = false;
+const SINGLE_BYTE_WRITE: bool = true;
+
+use crate::color::TriColor;
+
+pub(crate) mod command;
+use self::command::Command;
+use crate::buffer_len;
+
+/// Full size buffer for use with the 2.13" b V4 EPD
+#[cfg(feature = "graphics")]
+pub type Display2in13bV4 = crate::graphics::Display<
+    WIDTH,
+    HEIGHT,
+    false,
+    { buffer_len(WIDTH as usize, HEIGHT as usize * 2) },
+    TriColor,
+>;
+
+/// Epd2in13bV4 driver
+pub struct Epd2in13bV4<SPI, BUSY, DC, RST, DELAY> {
+    interface: DisplayInterface<SPI, BUSY, DC, RST, DELAY, SINGLE_BYTE_WRITE>,
+    color: TriColor,
+}
+
+impl<SPI, BUSY, DC, RST, DELAY> InternalWiAdditions<SPI, BUSY, DC, RST, DELAY>
+    for Epd2in13bV4<SPI, BUSY, DC, RST, DELAY>
+where
+    SPI: SpiDevice,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayNs,
+{
+    fn init(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        // Values taken from datasheet and sample code
+
+        // reset the device
+        self.interface.reset(delay, 20_000, 2_000);
+        self.wait_until_idle(spi, delay)?;
+
+        // reset s/w settings
+        self.interface.cmd(spi, Command::SwReset)?;
+        self.wait_until_idle(spi, delay)?;
+
+        // ???
+        self.cmd_with_data(spi, Command::DriverOutputControl, &[0xF9, 0x00, 0x00])?;
+
+        // Enter data entry mode
+        self.cmd_with_data(spi, Command::DataEntryModeSetting, &[0x03])?;
+
+        // Set the screen resolution
+        self.send_resolution(spi)?;
+
+        // Initialize the cursor
+        self.set_cursor(spi, 0, 0)?;
+
+        // Select border waveform
+        self.cmd_with_data(spi, Command::SelectBorderWaveform, &[0x05])?;
+
+        // Display update control
+        self.cmd_with_data(spi, Command::DisplayUpdateControl, &[0x80, 0x80])?;
+        self.wait_until_idle(spi, delay)?;
+
+        Ok(())
+    }
+}
+
+impl<SPI, BUSY, DC, RST, DELAY> WaveshareThreeColorDisplay<SPI, BUSY, DC, RST, DELAY>
+    for Epd2in13bV4<SPI, BUSY, DC, RST, DELAY>
+where
+    SPI: SpiDevice,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayNs,
+{
+    fn update_color_frame(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+        black: &[u8],
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.update_achromatic_frame(spi, delay, black)?;
+        self.update_chromatic_frame(spi, delay, chromatic)?;
+        Ok(())
+    }
+
+    /// Update only the black/white data of the display.
+    ///
+    /// Finish by calling `update_chromatic_frame`.
+    fn update_achromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        _delay: &mut DELAY,
+        black: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.set_cursor(spi, 0, 0)?;
+        self.interface.cmd(spi, Command::WriteRamBlackWhite)?;
+        self.interface.data(spi, black)?;
+
+        Ok(())
+    }
+
+    /// Update only chromatic data of the display.
+    ///
+    /// This data takes precedence over the black/white data.
+    fn update_chromatic_frame(
+        &mut self,
+        spi: &mut SPI,
+        _delay: &mut DELAY,
+        chromatic: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.set_cursor(spi, 0, 0)?;
+        self.interface.cmd(spi, Command::WriteRamRed)?;
+        // A TriColor display stores colored pixels as 1s in it's bitfield,
+        // but this screen considers 1s to be white, while 0s are
+        // considered  red. Therfore we have to flip the bitfiled before we
+        // send it to the device
+        let mut inverted_chromatic = [0u8; { NUM_DISPLAY_BYTES as usize}];
+        for (i, &byte) in chromatic.iter().enumerate() {
+            inverted_chromatic[i] = !byte;
+        }
+        self.interface.data(spi, &inverted_chromatic[..chromatic.len()])?;
+
+        Ok(())
+    }
+}
+
+impl<SPI, BUSY, DC, RST, DELAY> WaveshareDisplay<SPI, BUSY, DC, RST, DELAY>
+    for Epd2in13bV4<SPI, BUSY, DC, RST, DELAY>
+where
+    SPI: SpiDevice,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayNs,
+{
+    type DisplayColor = TriColor;
+    fn new(
+        spi: &mut SPI,
+        busy: BUSY,
+        dc: DC,
+        rst: RST,
+        delay: &mut DELAY,
+        delay_us: Option<u32>,
+    ) -> Result<Self, SPI::Error> {
+        let interface = DisplayInterface::new(busy, dc, rst, delay_us);
+        let color = DEFAULT_BACKGROUND_COLOR;
+
+        let mut epd = Epd2in13bV4 { interface, color };
+
+        epd.init(spi, delay)?;
+
+        Ok(epd)
+    }
+
+    fn sleep(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.cmd_with_data(spi, Command::DeepSleepMode, &[0x01])?;
+        delay.delay_us(200_000);
+        Ok(())
+    }
+
+    fn wake_up(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.init(spi, delay)
+    }
+
+    fn set_background_color(&mut self, color: TriColor) {
+        self.color = color;
+    }
+
+    fn background_color(&self) -> &TriColor {
+        &self.color
+    }
+
+    fn width(&self) -> u32 {
+        WIDTH
+    }
+
+    fn height(&self) -> u32 {
+        HEIGHT
+    }
+
+    fn update_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.set_cursor(spi, 0, 0)?;
+        self.update_achromatic_frame(spi, delay, buffer)?;
+
+        // Clear the chromatic layer
+        self.interface.cmd(spi, Command::WriteRamRed)?;
+        self.interface.data_x_times(spi, 0xFF, NUM_DISPLAY_BYTES)?;
+
+        Ok(())
+    }
+
+    #[allow(unused)]
+    fn update_partial_frame(
+        &mut self,
+        spi: &mut SPI,
+        delay: &mut DELAY,
+        buffer: &[u8],
+        x: u32,
+        y: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), SPI::Error> {
+        Ok(())
+    }
+
+    fn display_frame(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.command(spi, Command::MasterActivation)?;
+        self.wait_until_idle(spi, delay)?;
+        Ok(())
+    }
+
+    fn update_and_display_frame(
+        &mut self,
+        spi: &mut SPI,
+        buffer: &[u8],
+        delay: &mut DELAY,
+    ) -> Result<(), SPI::Error> {
+        self.update_frame(spi, buffer, delay)?;
+        self.display_frame(spi, delay)?;
+        Ok(())
+    }
+
+    fn clear_frame(&mut self, spi: &mut SPI, _delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.send_resolution(spi)?;
+
+        match DEFAULT_BACKGROUND_COLOR {
+            TriColor::Chromatic => {
+                // Clear the black
+                self.interface.cmd(spi, Command::WriteRamBlackWhite)?;
+                self.interface.data_x_times(spi, TriColor::White.get_byte_value(), NUM_DISPLAY_BYTES)?;
+                // Clear the chromatic
+                self.interface.cmd(spi, Command::WriteRamRed)?;
+                self.interface.data_x_times(spi, 0x00, NUM_DISPLAY_BYTES)?;
+            }
+            _ => {
+                // Clear the black
+                self.interface.cmd(spi, Command::WriteRamBlackWhite)?;
+                self.interface.data_x_times(spi, DEFAULT_BACKGROUND_COLOR.get_byte_value(), NUM_DISPLAY_BYTES)?;
+                // Clear the chromatic
+                self.interface.cmd(spi, Command::WriteRamRed)?;
+                self.interface.data_x_times(spi, 0xFF, NUM_DISPLAY_BYTES)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn set_lut(
+        &mut self,
+        _spi: &mut SPI,
+        _delay: &mut DELAY,
+        _refresh_rate: Option<RefreshLut>,
+    ) -> Result<(), SPI::Error> {
+        Ok(())
+    }
+
+    fn wait_until_idle(&mut self, _spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
+        self.interface.wait_until_idle(delay, IS_BUSY_LOW);
+        Ok(())
+    }
+}
+
+impl<SPI, BUSY, DC, RST, DELAY> Epd2in13bV4<SPI, BUSY, DC, RST, DELAY>
+where
+    SPI: SpiDevice,
+    BUSY: InputPin,
+    DC: OutputPin,
+    RST: OutputPin,
+    DELAY: DelayNs,
+{
+    fn command(&mut self, spi: &mut SPI, command: Command) -> Result<(), SPI::Error> {
+        self.interface.cmd(spi, command)
+    }
+
+    #[allow(unused)]
+    fn send_data(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
+        self.interface.data(spi, data)
+    }
+
+    fn cmd_with_data(
+        &mut self,
+        spi: &mut SPI,
+        command: Command,
+        data: &[u8],
+    ) -> Result<(), SPI::Error> {
+        self.interface.cmd_with_data(spi, command, data)
+    }
+
+    fn send_resolution(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+        let w = self.width();
+        let h = self.height();
+
+        self.set_window(spi, 0, 0, w, h)
+    }
+
+    fn set_window(&mut self, spi: &mut SPI, x: u32, y: u32, width: u32, height: u32) -> Result<(), SPI::Error> {
+        let xstart = x;
+        let xend = xstart + width;
+        let ystart = y;
+        let yend = ystart + height;
+
+        self.cmd_with_data(
+            spi,
+            Command::SetRamXAddressStartEndPosition, 
+            &[
+                ((xstart>>3) & 0xFF).try_into().unwrap(),
+                ((xend>>3) & 0xFF).try_into().unwrap()
+            ]
+        )?;
+        self.cmd_with_data(
+            spi,
+            Command::SetRamYAddressStartEndPosition,
+            &[
+                (ystart & 0xFF).try_into().unwrap(),
+                ((ystart >> 8) & 0xFF).try_into().unwrap(),
+                (yend & 0xFF).try_into().unwrap(),
+                ((yend >> 8) & 0xFF).try_into().unwrap()
+            ]
+        )?;
+
+        Ok(())
+    }
+
+    fn set_cursor(&mut self, spi: &mut SPI, x: u32, y: u32) -> Result<(), SPI::Error> {
+        self.cmd_with_data(
+            spi,
+            Command::SetRamXAddressCounter, 
+            &[
+                (x & 0xFF).try_into().unwrap()
+            ]
+        )?;
+        self.cmd_with_data(
+            spi,
+            Command::SetRamYAddressCounter, 
+            &[
+                (y & 0xFF).try_into().unwrap(), 
+                ((y >> 8) & 0xFF).try_into().unwrap()
+            ]
+        )?;
+        Ok(())
+    }
+
+    /// Set the outer border of the display to the chosen color.
+    pub fn set_border_color(&mut self, _spi: &mut SPI, _color: TriColor) -> Result<(), SPI::Error> {
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod epd1in54_v2;
 pub mod epd1in54b;
 pub mod epd1in54c;
 pub mod epd2in13_v2;
+pub mod epd2in13b_v4;
 pub mod epd2in13bc;
 pub mod epd2in66b;
 pub mod epd2in7b;


### PR DESCRIPTION
This PR adds support for 2.13" (b) V4 e-ink displays.

DEMO:

https://github.com/user-attachments/assets/84bb8b7b-d999-4b4d-b3e2-1623fc8fc593

<details>
  <summary>Demo source code</summary>

```rust
use embedded_graphics::{
    mono_font::MonoTextStyleBuilder,
    prelude::*,
    primitives::{Circle, Line, PrimitiveStyle},
    text::{Baseline, Text, TextStyleBuilder},
};
use embedded_hal::delay::DelayNs;
use epd_waveshare::{
    color::*,
    epd2in13b_v4::{Display2in13bV4, Epd2in13bV4},
    graphics::DisplayRotation,
    prelude::*,
};
use linux_embedded_hal::Delay;

use rppal::gpio::Gpio;
use rppal::spi::{Bus, Mode, SimpleHalSpiDevice, SlaveSelect, Spi};

// activate spi, gpio in raspi-config
// needs to be run with sudo because of some sysfs_gpio permission problems and follow-up timing problems
// see https://github.com/rust-embedded/rust-sysfs-gpio/issues/5 and follow-up issues
//
// This example first setups SPI communication using the pin layout found
// at https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT_(B). This example uses the layout for the
// Raspberry Pi Zero (RPI Zero). The Chip Select (CS) was taken from the ep2in9 example since CE0 (GPIO8) did
// not seem to work on RPI Zero with 2.13" HAT
//
// The first frame is filled with four texts at different rotations (black on white)
// The second frame uses a buffer for black/white and a seperate buffer for chromatic/white (i.e. red or yellow)
// This example draws a sample clock in black on white and two texts using white on red.
//
// after finishing, put the display to sleep

fn main() {
    let mut pwr = Gpio::new().unwrap().get(18).unwrap().into_output();
    pwr.set_high();

    // let busy = SysfsPin::new(24); // GPIO 24, board J-18
    // busy.export().expect("busy export");
    // while !busy.is_exported() {}
    // busy.set_direction(Direction::In).expect("busy Direction");
    let busy = Gpio::new().unwrap().get(24).unwrap().into_input();

    // let dc = SysfsPin::new(25); // GPIO 25, board J-22
    // dc.export().expect("dc export");
    // while !dc.is_exported() {}
    // dc.set_direction(Direction::Out).expect("dc Direction");
    // // dc.set_value(1).expect("dc Value set to 1");
    let dc = Gpio::new().unwrap().get(25).unwrap().into_output();

    // let rst = SysfsPin::new(17); // GPIO 17, board J-11
    // rst.export().expect("rst export");
    // while !rst.is_exported() {}
    // rst.set_direction(Direction::Out).expect("rst Direction");
    // // rst.set_value(1).expect("rst Value set to 1");
    let mut rst = Gpio::new().unwrap().get(17).unwrap().into_output();
    rst.set_low();

    // Configure Digital I/O Pin to be used as Chip Select for SPI
    // let cs = SysfsPin::new(26); // CE0, board J-24, GPIO 8 -> doesn work. use this from 2in19 example which works
    // cs.export().expect("cs export");
    // while !cs.is_exported() {}
    // cs.set_direction(Direction::Out).expect("CS Direction");
    // cs.set_value(1).expect("CS Value set to 1");
    let mut cs = Gpio::new().unwrap().get(8).unwrap().into_output();
    cs.set_low();

    // let pwr = Gpio::new().unwrap().get(18).unwrap().into_output();
    // cs.set_high();

    // Configure SPI
    // Settings are taken from
    let bus = Spi::new(Bus::Spi0, SlaveSelect::Ss0, 10_000_000, Mode::Mode0).unwrap();
    bus.set_bits_per_word(8).unwrap();
    bus.set_ss_polarity(rppal::spi::Polarity::ActiveLow)
        .unwrap();

    let mut spi = SimpleHalSpiDevice::new(bus);
    // let mut spi = SpidevDevice::open("/dev/spidev0.0").expect("spidev directory");
    // let options = SpidevOptions::new()
    //     .bits_per_word(8)
    //     .max_speed_hz(10_000_000)
    //     .mode(spidev::SpiModeFlags::SPI_MODE_0)
    //     .build();
    // spi.configure(&options).expect("spi configuration");

    let mut delay = Delay {};

    let mut epd2in13 =
        Epd2in13bV4::new(&mut spi, busy, dc, rst, &mut delay, None).expect("eink initalize error");

    println!("Test all the rotations");
    let mut display = Display2in13bV4::default();
    display.clear(TriColor::White).ok();

    display.set_rotation(DisplayRotation::Rotate0);
    draw_text(&mut display, "Rotation 0!", 0, 0);

    display.set_rotation(DisplayRotation::Rotate90);
    draw_text(&mut display, "Rotation 90!", 0, 0);

    display.set_rotation(DisplayRotation::Rotate180);
    draw_text(&mut display, "Rotation 180!", 0, 0);

    display.set_rotation(DisplayRotation::Rotate270);
    draw_text(&mut display, "Rotation 270!", 0, 0);

    epd2in13
        .update_and_display_frame(&mut spi, display.bw_buffer(), &mut delay)
        .expect("display frame new graphics");

    println!("Waiting 5s");
    delay.delay_ms(5000);

    println!("Drawing an analog clock and some text");
    display.set_rotation(DisplayRotation::Rotate0);
    display.clear(TriColor::White).ok();

    // draw a analog clock
    let _ = Circle::with_center(Point::new(60, 60), 120)
        .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 2))
        .draw(&mut display);
    let _ = Line::new(Point::new(60, 60), Point::new(76, 28))
        .into_styled(PrimitiveStyle::with_stroke(TriColor::Black, 4))
        .draw(&mut display);
    let _ = Line::new(Point::new(60, 60), Point::new(31, 19))
        .into_styled(PrimitiveStyle::with_stroke(TriColor::Chromatic, 2))
        .draw(&mut display);

    epd2in13
        .update_color_frame(
            &mut spi,
            &mut delay,
            display.bw_buffer(),
            display.chromatic_buffer(),
        )
        .unwrap();
    epd2in13
        .display_frame(&mut spi, &mut delay)
        .expect("display frame new graphics");

    println!("Waiting 5s");
    delay.delay_ms(5000);

    println!("Testing diferent fonts and colors");
    display.clear(TriColor::White).ok();
    // draw text white on Red background by using the chromatic buffer
    let style = MonoTextStyleBuilder::new()
        .font(&embedded_graphics::mono_font::ascii::FONT_6X10)
        .text_color(TriColor::White)
        .background_color(TriColor::Chromatic)
        .build();
    let text_style = TextStyleBuilder::new().baseline(Baseline::Top).build();

    let _ = Text::with_text_style("It's working", Point::new(15, 10), style, text_style)
        .draw(&mut display);

    // use bigger/different font
    let style = MonoTextStyleBuilder::new()
        .font(&embedded_graphics::mono_font::ascii::FONT_10X20)
        .text_color(TriColor::Chromatic)
        .background_color(TriColor::Black)
        .build();

    let _ = Text::with_text_style("It's working", Point::new(0, 40), style, text_style)
        .draw(&mut display);

    // we used three colors, so we need to update both bw-buffer and chromatic-buffer

    epd2in13
        .update_color_frame(
            &mut spi,
            &mut delay,
            display.bw_buffer(),
            display.chromatic_buffer(),
        )
        .unwrap();
    epd2in13
        .display_frame(&mut spi, &mut delay)
        .expect("display frame new graphics");

    println!("Waiting 5s");
    delay.delay_ms(5000);

    // clear both bw buffer and chromatic buffer
    println!("Clearing screen");
    display.clear(TriColor::White).ok();
    epd2in13
        .update_color_frame(
            &mut spi,
            &mut delay,
            display.bw_buffer(),
            display.chromatic_buffer(),
        )
        .unwrap();
    epd2in13.display_frame(&mut spi, &mut delay).unwrap();

    println!("Finished tests - going to sleep");
    epd2in13.sleep(&mut spi, &mut delay).unwrap();
}

fn draw_text(display: &mut Display2in13bV4, text: &str, x: i32, y: i32) {
    let style = MonoTextStyleBuilder::new()
        .font(&embedded_graphics::mono_font::ascii::FONT_6X10)
        .text_color(TriColor::White)
        .background_color(TriColor::Black)
        .build();

    let text_style = TextStyleBuilder::new().baseline(Baseline::Top).build();

    let _ = Text::with_text_style(text, Point::new(x, y), style, text_style).draw(display);
}

```
</details>

I didn't look into how other screens are implemented and based my code mostly off the bc version, so there might be superfluous code here. I'd appreciate some pointers on what can be removed or improved.

This screen renders color differently from the bc version. Instead of red pixels being represented with a 1, they are represented with a zero. I couldn't find a way to define this on the display level, so I ended up just inverting the bits before I send them off to the screen.