### PR TITLE
Implement PixelColor for Color and TriColor

### DIFF
--- a/examples/epd7in5_v2.rs
+++ b/examples/epd7in5_v2.rs
@@ -8,7 +8,6 @@ use embedded_graphics::{
     primitives::{Circle, Line, PrimitiveStyleBuilder},
     text::{Baseline, Text, TextStyleBuilder},
 };
-use embedded_graphics_core::pixelcolor::{BinaryColor, PixelColor};
 use embedded_hal::delay::DelayNs;
 #[cfg(feature = "graphics")]
 use epd_waveshare::{color::Color, epd7in5_v2::*, graphics::DisplayRotation, prelude::*};
@@ -147,9 +146,9 @@ fn main() -> Result<(), SPIError> {
     println!("Draw Ferris");
     display.clear(Color::Black).ok();
     let data = include_bytes!("./assets/ferris.raw");
-    let raw_image = ImageRaw::<BinaryColor>::new(data, 460);
+    let raw_image = ImageRaw::<Color>::new(data, 460);
     let image = Image::new(&raw_image, Point::zero());
-    image.draw(&mut display.color_converted()).unwrap();
+    image.draw(&mut display).unwrap();
     epd7in5.update_and_display_frame(&mut spi, display.buffer(), &mut delay)?;
 
     // Clear and sleep

--- a/src/color.rs
+++ b/src/color.rs
@@ -289,8 +289,20 @@ impl From<u8> for Color {
 }
 
 #[cfg(feature = "graphics")]
+impl From<embedded_graphics_core::pixelcolor::raw::RawU1> for Color {
+    fn from(b: embedded_graphics_core::pixelcolor::raw::RawU1) -> Self {
+        use embedded_graphics_core::prelude::RawData;
+        if b.into_inner() == 0 {
+            Color::White
+        } else {
+            Color::Black
+        }
+    }
+}
+
+#[cfg(feature = "graphics")]
 impl PixelColor for Color {
-    type Raw = ();
+    type Raw = embedded_graphics_core::pixelcolor::raw::RawU1;
 }
 
 #[cfg(feature = "graphics")]
@@ -352,8 +364,22 @@ impl TriColor {
 }
 
 #[cfg(feature = "graphics")]
+impl From<embedded_graphics_core::pixelcolor::raw::RawU2> for TriColor {
+    fn from(b: embedded_graphics_core::pixelcolor::raw::RawU2) -> Self {
+        use embedded_graphics_core::prelude::RawData;
+        if b.into_inner() == 0b00 {
+            TriColor::White
+        } else if b.into_inner() == 0b01 {
+            TriColor::Black
+        } else {
+            TriColor::Chromatic
+        }
+    }
+}
+
+#[cfg(feature = "graphics")]
 impl PixelColor for TriColor {
-    type Raw = ();
+    type Raw = embedded_graphics_core::pixelcolor::raw::RawU2;
 }
 
 #[cfg(feature = "graphics")]


### PR DESCRIPTION
`OctColor` already has an implementation for `PixelColor`. I added implementations for `Color` and `TriColor`, so that one can draw images without using `color_converted()`.
The documentation of `color_converted` says, it should be avoided (see [here](https://docs.rs/embedded-graphics/latest/embedded_graphics/draw_target/trait.DrawTargetExt.html#tymethod.color_converted)). So I think this might be helpful.