### PR TITLE
Fix update_old_frame for epd2in9_v2

### DIFF
--- a/src/epd2in9_v2/mod.rs
+++ b/src/epd2in9_v2/mod.rs
@@ -418,6 +418,8 @@ where
     ) -> Result<(), SPI::Error> {
         self.wait_until_idle(spi, delay)?;
         self.interface
+            .cmd_with_data(spi, Command::WriteRam, buffer)?;
+        self.interface
             .cmd_with_data(spi, Command::WriteRam2, buffer)
     }
 


### PR DESCRIPTION
The problem was introduced in #103 and leads to some pixels not updated in the next quick refresh after a full refresh. The function `update_old_frame` now does the same thing as `SetFrameMemory_Base`in the original C code [here](https://github.com/waveshareteam/e-Paper/blob/af4d8b49ccef5f8f5fb88e9a836b86bd3f0bbfe3/Arduino/epd2in9_V2/epd2in9_V2.cpp#L425C11-L425C30).