### PR TITLE
Update real minimum required version to 1.62

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 repository = "https://github.com/Caemor/epd-waveshare.git"
 version = "0.6.0"
 edition = "2021"
+rust-version = "1.62"
 
 [dependencies]
 embedded-graphics-core = { version = "0.4", optional = true }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Display ones).
 
 It uses the [embedded graphics](https://crates.io/crates/embedded-graphics) library for the optional graphics support.
 
-A 2018-edition compatible version (Rust 1.31+) is needed.
+A 2021-edition compatible version (Rust 1.62+) is needed.
 
 Other similar libraries with support for much more displays are [u8g2](https://github.com/olikraus/u8g2)
 and [GxEPD](https://github.com/ZinggJM/GxEPD) for arduino.
@@ -46,6 +46,7 @@ epd4in2.update_and_display_frame(&mut spi, display.buffer(), &mut delay).expect(
 // Going to sleep
 epd4in2.sleep(&mut spi, &mut delay)
 ```
+
 > Check the complete example [here](./examples/epd4in2.rs).
 
 ## (Supported) Devices

--- a/src/epd2in13_v2/command.rs
+++ b/src/epd2in13_v2/command.rs
@@ -89,7 +89,6 @@ impl DriverOutput {
 ///  | | `------------- load temp
 ///  | `--------------- enable clock
 ///  `----------------- enable analog
-
 pub(crate) struct DisplayUpdateControl2(pub u8);
 #[allow(dead_code)]
 impl DisplayUpdateControl2 {

--- a/src/epd2in9d/mod.rs
+++ b/src/epd2in9d/mod.rs
@@ -291,10 +291,10 @@ where
     RST: OutputPin,
     DELAY: DelayNs,
 {
-    /// Wake Up Screen
-    ///
-    /// After the screen sleeps, it enters deep sleep mode. If you need to refresh the screen while in deep sleep mode, you must first execute awaken().
-    /// Wake the screen.
+    // /// Wake Up Screen
+    // ///
+    // /// After the screen sleeps, it enters deep sleep mode. If you need to refresh the screen while in deep sleep mode, you must first execute awaken().
+    // /// Wake the screen.
     // fn awaken(&mut self, spi: &mut SPI, delay: &mut DELAY) -> Result<(), SPI::Error> {
     //     // reset the device
     //     self.interface.reset(delay, 20_000, 2_000);

--- a/src/epd5in65f/command.rs
+++ b/src/epd5in65f/command.rs
@@ -111,10 +111,10 @@ pub(crate) enum Command {
     /// This command defines alternative resolution and this setting is of higher priority
     /// than the RES\[1:0\] in R00H (PSR).
     TconResolution = 0x61,
-    /// This command defines MCU host direct access external memory mode.
+    // /// This command defines MCU host direct access external memory mode.
     //SpiFlashControl = 0x65,
 
-    /// The LUT_REV / Chip Revision is read from OTP address = 25001 and 25000.
+    // /// The LUT_REV / Chip Revision is read from OTP address = 25001 and 25000.
     //Revision = 0x70,
     /// This command reads the IC status.
     GetStatus = 0x71,

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -192,7 +192,7 @@ pub struct VarDisplay<'a, COLOR: ColorType + PixelColor> {
 }
 
 /// For use with embedded_grahics
-impl<'a, COLOR: ColorType + PixelColor> DrawTarget for VarDisplay<'a, COLOR> {
+impl<COLOR: ColorType + PixelColor> DrawTarget for VarDisplay<'_, COLOR> {
     type Color = COLOR;
     type Error = core::convert::Infallible;
 
@@ -208,7 +208,7 @@ impl<'a, COLOR: ColorType + PixelColor> DrawTarget for VarDisplay<'a, COLOR> {
 }
 
 /// For use with embedded_grahics
-impl<'a, COLOR: ColorType + PixelColor> OriginDimensions for VarDisplay<'a, COLOR> {
+impl<COLOR: ColorType + PixelColor> OriginDimensions for VarDisplay<'_, COLOR> {
     fn size(&self) -> Size {
         match self.rotation {
             DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
@@ -296,7 +296,7 @@ impl<'a, COLOR: ColorType + PixelColor> VarDisplay<'a, COLOR> {
 }
 
 /// Some Tricolor specifics
-impl<'a> VarDisplay<'a, TriColor> {
+impl VarDisplay<'_, TriColor> {
     /// get black/white internal buffer to use it (to draw in epd)
     pub fn bw_buffer(&self) -> &[u8] {
         &self.buffer[..self.buffer_size() / 2]


### PR DESCRIPTION
I updated the minimum rust version to 1.62 after checking for it with mrsv. Example dependencies need 1.65 (nix).