### PR TITLE
Derive Default for Color, TriColor and OctColor

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -25,31 +25,34 @@ impl OutOfColorRangeParseError {
 
 /// Only for the Black/White-Displays
 // TODO : 'color' is not a good name for black and white, rename it to BiColor/BWColor ?
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum Color {
     /// Black color
     Black,
     /// White color
+    #[default]
     White,
 }
 
 /// Only for the Black/White/Color-Displays
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum TriColor {
     /// Black color
     Black,
     /// White color
+    #[default]
     White,
     /// Chromatic color
     Chromatic,
 }
 
 /// For the 7 Color Displays
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
 pub enum OctColor {
     /// Black Color
     Black = 0x00,
     /// White Color
+    #[default]
     White = 0x01,
     /// Green Color
     Green = 0x02,


### PR DESCRIPTION
This matches [`BinaryColor`](https://docs.rs/embedded-graphics/latest/embedded_graphics/pixelcolor/enum.BinaryColor.html#impl-Default-for-BinaryColor) in  `embedded-graphics`.

While I don't think anyone should particularly be relying on the output of `Color::default()`, the [`embedded-text`](https://docs.rs/embedded-text/latest/embedded_text/) crate has a trait bound of `C: PixelColor + Default`, which it uses it when "resetting" a style - just to have *something* to temporarily set the text colour to, presumably with the assumption that if it's being reset, it's about to be set to something sensible again in a moment.

https://github.com/embedded-graphics/embedded-text/blob/ea5271d32512eeed7a6caadf09509ff5d2447c63/src/rendering/line.rs#L24-L42

Given `BinaryColor` already has a similar behaviour, I figure this seems like a simple enough trait bound to simply satisfy like this. This patch is currently being successfully used in one of my own projects.