### PR TITLE
Fix Epd7in5_V2 content fading out during DisplayFrame

### DIFF
--- a/src/epd7in5_v2/mod.rs
+++ b/src/epd7in5_v2/mod.rs
@@ -70,17 +70,16 @@ where
         // and as per specs:
         // https://www.waveshare.com/w/upload/6/60/7.5inch_e-Paper_V2_Specification.pdf
 
-        self.cmd_with_data(spi, Command::BoosterSoftStart, &[0x17, 0x17, 0x27, 0x17])?;
-        self.cmd_with_data(spi, Command::PowerSetting, &[0x07, 0x17, 0x3F, 0x3F])?;
+        self.cmd_with_data(spi, Command::PowerSetting, &[0x07, 0x07, 0x3f, 0x3f])?;
+        self.cmd_with_data(spi, Command::BoosterSoftStart, &[0x17, 0x17, 0x28, 0x17])?;
         self.command(spi, Command::PowerOn)?;
+        delay.delay_ms(100);
         self.wait_until_idle(spi, delay)?;
         self.cmd_with_data(spi, Command::PanelSetting, &[0x1F])?;
-        self.cmd_with_data(spi, Command::PllControl, &[0x06])?;
         self.cmd_with_data(spi, Command::TconResolution, &[0x03, 0x20, 0x01, 0xE0])?;
         self.cmd_with_data(spi, Command::DualSpi, &[0x00])?;
-        self.cmd_with_data(spi, Command::TconSetting, &[0x22])?;
         self.cmd_with_data(spi, Command::VcomAndDataIntervalSetting, &[0x10, 0x07])?;
-        self.wait_until_idle(spi, delay)?;
+        self.cmd_with_data(spi, Command::TconSetting, &[0x22])?;
         Ok(())
     }
 }


### PR DESCRIPTION
I had an issue with the `Epd7in5_V2` driver. I could init and write graphics to the SRAM, as I could see the result being inverted (flickering) during the display refresh. But during the flickering, the content faded out. The result was barely seeable light light gray text and graphic on the display.

This did not happen when using the demo from waveshare (download [here](https://files.waveshare.com/upload/5/50/E-Paper_ESP32_Driver_Board_Code.7z)). So i copied the init procedure and it worked! My display now shows everything crispy black on white!

I do not know what `exactly` went wrong, but it works now and I wanted to spare others wasting hours (_days_) of their lives. I could "bisect" the changed lines to see what is causing the problem to be fixed, if that is wanted.

Otherwise thanks for the implementation, the rest works like a charm.

To test or use this library define this fork as crate in the `Cargo.toml`:

```toml
epd-waveshare = { git = "https://github.com/julianbuettner/epd-waveshare.git" }
```